### PR TITLE
change the data type of the env_step to np.int64

### DIFF
--- a/track_mjx/agent/custom_ppo.py
+++ b/track_mjx/agent/custom_ppo.py
@@ -61,7 +61,7 @@ class TrainingState:
     optimizer_state: optax.OptState
     params: ppo_losses.PPONetworkParams
     normalizer_params: running_statistics.RunningStatisticsState
-    env_steps: jnp.ndarray
+    env_steps: np.int64
 
 
 def _unpmap(v):
@@ -412,14 +412,10 @@ def train(
         value=ppo_network.value_network.init(key_value),
     )
     training_state = TrainingState(  # pytype: disable=wrong-arg-types  # jax-ndarray
-        optimizer_state=optimizer.init(
-            init_params
-        ),  # pytype: disable=wrong-arg-types  # numpy-scalars
+        optimizer_state=optimizer.init(init_params),  # pytype: disable=wrong-arg-types  # numpy-scalars
         params=init_params,
-        normalizer_params=running_statistics.init_state(
-            specs.Array(env_state.obs.shape[-1:], jnp.dtype("float32"))
-        ),
-        env_steps=0,
+        normalizer_params=running_statistics.init_state(specs.Array(env_state.obs.shape[-1:], jnp.dtype("float32"))),
+        env_steps=np.int64(0),
     )
     training_state = jax.device_put_replicated(
         training_state, jax.local_devices()[:local_devices_to_use]


### PR DESCRIPTION
This will fix the stepping overflow bug mentioned in #32.