### PR TITLE
update jax ver, minor fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "dm_control",
     "mujoco-mjx",
     "mediapy",
-    "jax[cuda12]==0.4.38",
+    "jax[cuda12]==0.4.34",
     "flax",
     "optax",
     "mediapy",

--- a/track_mjx/agent/mlp_ppo/ppo.py
+++ b/track_mjx/agent/mlp_ppo/ppo.py
@@ -38,6 +38,7 @@ import wandb
 
 from track_mjx.agent.mlp_ppo import losses, ppo_networks
 from track_mjx.environment import wrappers
+from track_mjx.agent import checkpointing
 
 import flax
 from flax import traverse_util
@@ -63,9 +64,6 @@ class TrainingState:
     params: losses.PPONetworkParams
     normalizer_params: running_statistics.RunningStatisticsState
     env_steps: jnp.ndarray
-
-
-from track_mjx.agent import checkpointing
 
 
 def _unpmap(v):

--- a/track_mjx/environment/task/single_clip_tracking.py
+++ b/track_mjx/environment/task/single_clip_tracking.py
@@ -137,19 +137,6 @@ class SingleClipTracking(PipelineEnv):
 
         low, hi = -self._reset_noise_scale, self._reset_noise_scale
 
-        # # Add pos
-        # qpos_with_pos = jp.array(self.sys.qpos0).at[:3].set(reference_frame.position)
-
-        # # Add quat
-        # new_qpos = qpos_with_pos.at[3:7].set(reference_frame.quaternion)
-
-        # # Add noise
-        # qpos = new_qpos + jp.where(
-        #     noise,
-        #     jax.random.uniform(rng1, (self.sys.nq,), minval=low, maxval=hi),
-        #     jp.zeros((self.sys.nq,)),
-        # )
-
         new_qpos = jp.concatenate(
             (
                 reference_frame.position,
@@ -364,11 +351,6 @@ class SingleClipTracking(PipelineEnv):
                 body_pos_dist_local,
             ]
         )
-
-        # jax.debug.print("track_pos_local: {}", track_pos_local)
-        # jax.debug.print("quat_dist: {}", quat_dist)
-        # jax.debug.print("joint_dist: {}", joint_dist)
-        # jax.debug.print("body_pos_dist_local: {}", body_pos_dist_local)
 
         prorioceptive_obs = jp.concatenate(
             [


### PR DESCRIPTION
turns out jax==0.4.38 is not reliable (https://github.com/jax-ml/jax/issues/26162) so lowering to 0.4.34

and fixed some config checkpointing logic (was previously passing the wrong config into the ppo train function for loading the network

also, removed persistent compilation cache for now