### PR TITLE
Update pyproject.toml with brax versioning to 0.12.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12"]
 dependencies = [
-    "brax",
+    "brax==0.12.3",
     "wandb",
     "mujoco",
     "dm_control",


### PR DESCRIPTION
If you upgrade brax to 0.12.4 then you can't import brax.v1