### PR TITLE
Update pyproject.toml to pin mujoco and dm control versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ classifiers = [
 dependencies = [
     "brax==0.12.3",
     "wandb",
-    "mujoco",
-    "dm_control",
-    "mujoco-mjx",
+    "mujoco==3.3.2",
+    "dm_control==1.0.30",
+    "mujoco-mjx==3.3.2",
     "mediapy",
     "jax[cuda12]==0.4.34",
     "flax",


### PR DESCRIPTION
Loading of xml models in newer versions of mujoco + dm control break the loading of the rat xml models. Pinning to last working version