### PR TITLE
Expanding observation space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ wandb/
 outputs/
 rollouts/
 patch.ipynb
+jax_cache/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/track_mjx/environment/task/single_clip_tracking.py
+++ b/track_mjx/environment/task/single_clip_tracking.py
@@ -399,12 +399,26 @@ class SingleClipTracking(PipelineEnv):
             data.qpos,
         )
 
+        # compute velocity-based differences
+        track_vel_local = self.walker.compute_local_track_velocities_with_qpos(
+            ref_traj.velocity, data.qvel, data.qpos
+        )
+        angular_vel_dist = self.walker.compute_angular_velocity_distances(
+            ref_traj.angular_velocity, data.qvel
+        )
+        joint_vel_dist = self.walker.compute_joint_velocity_distances(
+            ref_traj.joints_velocity, data.qvel
+        )
+
         reference_obs = jp.concatenate(
             [
                 track_pos_local,
                 quat_dist,
                 joint_dist,
                 body_pos_dist_local,
+                track_vel_local,
+                angular_vel_dist,
+                joint_vel_dist,
             ]
         )
 


### PR DESCRIPTION
## **WORK IN PROGRESS**

`single_clip_tracking.py` now computes differences in velocity between the proprioceptive frame and the reference observation, rotated to the frame of the agent. It does so for the root position, root quats, and joint angles.