### PR TITLE
Fixed reference to model_path

### DIFF
--- a/track_mjx/config/rodent-full-clips.yaml
+++ b/track_mjx/config/rodent-full-clips.yaml
@@ -88,7 +88,7 @@ logging_config:
   group_name: position_actuator
   exp_name: position_actuator
   clip_id: -1
-  model_path: /home/mila/a/aidan.sirbu/scratch/track-mjx/model_checkpoints
+  model_path: model_checkpoints
   algo_name: ppo
   rollout_metrics:
     - pos_reward


### PR DESCRIPTION
## Changes:
`rodent-full-clips.yaml`:
- Converted `model_path` to relative path