### PR TITLE
fix step logging in wandb

### DIFF
--- a/track_mjx/agent/mlp_ppo/ppo.py
+++ b/track_mjx/agent/mlp_ppo/ppo.py
@@ -756,8 +756,6 @@ def train(
                     metrics,
                     data_split="test_set",
                 )
-            logging.info(metrics)
-            progress_fn(current_step, metrics)
 
             policy_param = _unpmap(
                 (training_state.normalizer_params, training_state.params.policy)
@@ -781,6 +779,10 @@ def train(
                     policy_params_fn_key=policy_params_fn_key,
                     render_video=False,
                 )
+
+            # log metrics
+            logging.info(metrics)
+            progress_fn(current_step, metrics)
             # Save checkpoint
             if ckpt_mgr is not None:
                 checkpointing.save(

--- a/track_mjx/agent/wandb_logging.py
+++ b/track_mjx/agent/wandb_logging.py
@@ -111,7 +111,7 @@ def rollout_logging_fn(
                 f"latents/latent_logvars_mean{i}": latent_logvars_means[i],
                 f"latents/latent_logvars_std{i}": latent_logvars_stds[i],
             },
-            commit=True,
+            commit=False,
         )
     if render_video:
         video_path = f"{model_path}/{current_step}.mp4"
@@ -121,7 +121,9 @@ def rollout_logging_fn(
                 log_lineplot_to_wandb(
                     f"eval/rollout_{rollout_metric}",
                     rollout_metric,
-                    list(enumerate([state.metrics[rollout_metric] for state in rollout])),
+                    list(
+                        enumerate([state.metrics[rollout_metric] for state in rollout])
+                    ),
                     title=f"{rollout_metric} for each rollout frame",
                 )
 
@@ -158,7 +160,10 @@ def rollout_logging_fn(
                 width=640,
             )
             media.write_video(video_path, frames, fps=fps, qp=18)
-        wandb.log({"videos/rollout": wandb.Video(video_path, format="mp4")})
+        wandb.log(
+            {"videos/rollout": wandb.Video(video_path, format="mp4")},
+            commit=False,
+        )
 
 
 def log_lineplot_to_wandb(name: str, metric_name: str, data: jp.ndarray, title: str):
@@ -191,5 +196,5 @@ def log_lineplot_to_wandb(name: str, metric_name: str, data: jp.ndarray, title: 
                 title=title,
             )
         },
-        commit=True,
+        commit=False,
     )


### PR DESCRIPTION
`progress_fn` commits logs after each eval step, so by setting `commit=False` for every other log (our custom rollout logging metrics), the wandb `Step` variable will accurately track the number of eval steps that have occurred. 

Other metrics like `num_steps_thousands` are often better measures for the x-axis, but this fixes the Step alignment with number of evals. 