### PR TITLE
Fixed proprioceptive and reference observations

### DIFF
--- a/track_mjx/environment/task/single_clip_tracking.py
+++ b/track_mjx/environment/task/single_clip_tracking.py
@@ -338,7 +338,7 @@ class SingleClipTracking(PipelineEnv):
         qpos = data.qpos[7:] # skip the root joint
         qvel = data.qvel[6:] # skip the root joint velocity
         actuator_ctrl = data.qfrc_actuator
-        _, body_height, _ = data.bind(self._mjx_model, self._mj_spec.body(self.walker._torso_name)).xpos
+        _, _, body_height = data.bind(self._mjx_model, self._mj_spec.body(self.walker._torso_name)).xpos
         world_zaxis = data.bind(self._mjx_model, self._mj_spec.body(self.walker._torso_name)).xmat.flatten()[6:]
         appendages_pos = self._get_appendages_pos(data)
         proprioception = jp.concatenate(
@@ -433,17 +433,20 @@ class SingleClipTracking(PipelineEnv):
         )
 
         # align with https://github.com/google-deepmind/mujoco_playground/blob/ff0ea5629bd89662f6ffa54464e247653737ea45/mujoco_playground/_src/locomotion/go1/joystick.py#L316-L332
-        proprioceptive_obs = jp.concatenate(
-            [
-                data.qpos[7:],
-                data.qvel[6:],
-                data.qfrc_actuator,
-                self._get_appendages_pos(data),
-                self._get_kinematic_sensors(data),
-                # touch does not work for multiple GPUs for now
-                # self._get_touch_sensors(data),
-            ]
-        )
+        # proprioceptive_obs = jp.concatenate(
+        #     [
+        #         data.qpos[7:],
+        #         data.qvel[6:],
+        #         data.qfrc_actuator,
+        #         self._get_appendages_pos(data),
+        #         self._get_kinematic_sensors(data),
+        #         # touch does not work for multiple GPUs for now
+        #         # self._get_touch_sensors(data),
+        #     ]
+        # )
+
+        proprioceptive_obs = self._get_proprioception(data)
+
         return reference_obs, proprioceptive_obs
 
     def _get_cur_frame(self, info, data: mjx.Data) -> jp.ndarray:

--- a/track_mjx/environment/walker/base.py
+++ b/track_mjx/environment/walker/base.py
@@ -222,7 +222,14 @@ class BaseWalker(ABC):
             Joint distances Shape (num_joints,).
         """
         joints = self.get_all_loc_joints(qpos)
-        joint_dist = (ref_joints - joints)[:, self._joint_idxs].flatten()
+        # joint_dist = (ref_joints - joints)[:, self._joint_idxs].flatten()
+
+        # Hot fix for OB1 error
+        joint_indices = self._joint_idxs - 1
+        joint_dist = (ref_joints - joints)[:, joint_indices].flatten()
+
+        # Include all joints
+        # joint_dist = (ref_joints - joints).flatten()
 
         return joint_dist
 


### PR DESCRIPTION
# Fixes
- Uses `_get_proprioception()` inside of `_get_obs()` when building observations (alligned with `vnl_playground`)
- Fixes off-by-one error when indexing which joints to include inside of the reference observations