### PR TITLE
Make reference data loading work for non editable installs

### DIFF
--- a/track_mjx/analysis/rollout.py
+++ b/track_mjx/analysis/rollout.py
@@ -135,19 +135,19 @@ def create_rollout_generator(
     while hasattr(unwrapped_env, "_env"):
         unwrapped_env = unwrapped_env._env
     reference_clips = unwrapped_env.reference_clips
+    reference_qpos = reference_clips.qpos
 
     def _build_step_output(state, ctrl, extras):
         """Build the per-step output dict."""
         time_in_frames = state.data.time * mocap_hz
         frame = jnp.floor(time_in_frames + state.info["start_frame"]).astype(int)
-        clip = state.info["reference_clip"]
-        ref = reference_clips.at(clip=clip, frame=frame)
-
+        clip = jnp.asarray(state.info["reference_clip"]).astype(int)
         step_output = {
             "qpos": state.data.qpos,
-            "qpos_ref": ref.qpos,
             "ctrl": ctrl,
             "reward": state.reward,
+            "frame": frame,
+            "clip": clip,
         }
 
         if log_activations:
@@ -235,14 +235,14 @@ def create_rollout_generator(
         final_frame = jnp.floor(
             final_time_in_frames + final_state.info["start_frame"]
         ).astype(int)
-        final_clip = final_state.info["reference_clip"]
-        final_ref = reference_clips.at(clip=final_clip, frame=final_frame)
+        final_clip = jnp.asarray(final_state.info["reference_clip"]).astype(int)
+        rollout_frames = jnp.concatenate([outputs["frame"], final_frame[None]], axis=0)
+        rollout_clips = jnp.concatenate([outputs["clip"], final_clip[None]], axis=0)
+        qposes_ref = reference_qpos[rollout_clips, rollout_frames]
 
         # Build result dict with core fields
         result = {
-            "qposes_ref": jnp.concatenate(
-                [outputs["qpos_ref"], final_ref.qpos[None]], axis=0
-            ),
+            "qposes_ref": qposes_ref,
             "qposes_rollout": jnp.concatenate(
                 [outputs["qpos"], final_state.data.qpos[None]], axis=0
             ),

--- a/track_mjx/config/utils.py
+++ b/track_mjx/config/utils.py
@@ -95,18 +95,29 @@ def prepare_config(
     """
     walker_name = cfg.walker_config.walker_name
 
+    # Use explicitly provided data_path if available, otherwise resolve from
+    # project root. This ensures the path is correct for non-editable installs
+    # where _PROJECT_ROOT would point into site-packages/.
+    explicit_data_path = OmegaConf.select(cfg, "data_path", default=None)
+
     if walker_name == "rodent":
         logging.info("Using rodent walker")
         walker_xml_path = str(rodent_consts.RODENT_XML_PATH)
         arena_xml_path = str(rodent_consts.ARENA_XML_PATH)
-        reference_data_path = _resolve_data_path(
-            "data/rodent/rodent_reference_clips.h5"
+        reference_data_path = (
+            str(explicit_data_path)
+            if explicit_data_path is not None
+            else _resolve_data_path("data/rodent/rodent_reference_clips.h5")
         )
     elif walker_name == "fruitfly":
         logging.info("Using fruitfly walker")
         walker_xml_path = str(fruitfly_consts.FRUITFLY_XML_PATH)
         arena_xml_path = str(fruitfly_consts.ARENA_XML_PATH)
-        reference_data_path = _resolve_data_path("data/fruitfly/fly_reference_clip.h5")
+        reference_data_path = (
+            str(explicit_data_path)
+            if explicit_data_path is not None
+            else _resolve_data_path("data/fruitfly/fly_reference_clip.h5")
+        )
     elif walker_name == "celegans":
         logging.info("Using celegans walker")
         raise NotImplementedError("Celegans walker not implemented yet.")


### PR DESCRIPTION
If the repo was not installed in editable mode, then it would try to find the reference data in `site-packages`. This PR adds a fix in the config loading utility which loads using the explicit reference data path when available.

Also moved rollout reference extraction outside of the scan (10+min single rollout to <1.5min)