### PR TITLE
fix(ppo): remove num_resets_per_eval factor inflating training/sps

### DIFF
--- a/track_mjx/agent/ff_ppo/ppo.py
+++ b/track_mjx/agent/ff_ppo/ppo.py
@@ -481,10 +481,13 @@ def train(
 
         epoch_training_time = time.time() - t
         training_walltime += epoch_training_time
+        # epoch_training_time times a single training_epoch (one iteration of the
+        # `for _ in range(max(num_resets_per_eval, 1))` reset loop in the main
+        # training loop). num_training_steps_per_epoch already divides the step
+        # budget by num_resets_per_eval, so multiplying the numerator by it again
+        # double-counts and over-reports sps by exactly that factor.
         sps = (
-            num_training_steps_per_epoch
-            * env_step_per_training_step
-            * max(num_resets_per_eval, 1)
+            num_training_steps_per_epoch * env_step_per_training_step
         ) / epoch_training_time
         metrics = {
             "training/sps": sps,

--- a/track_mjx/agent/recurrent_ppo/ppo.py
+++ b/track_mjx/agent/recurrent_ppo/ppo.py
@@ -730,10 +730,13 @@ def train(
 
         epoch_training_time = time.time() - t
         training_walltime += epoch_training_time
+        # epoch_training_time times a single training_epoch (one iteration of the
+        # `for _ in range(max(num_resets_per_eval, 1))` reset loop in the main
+        # training loop). num_training_steps_per_epoch already divides the step
+        # budget by num_resets_per_eval, so multiplying the numerator by it again
+        # double-counts and over-reports sps by exactly that factor.
         sps = (
-            num_training_steps_per_epoch
-            * env_step_per_training_step
-            * max(num_resets_per_eval, 1)
+            num_training_steps_per_epoch * env_step_per_training_step
         ) / epoch_training_time
         metrics = {
             "training/sps": sps,


### PR DESCRIPTION
## Summary

`training/sps` logged during PPO training over-reports throughput by **exactly `num_resets_per_eval`** (`= eval_every // reset_every`). The fix removes the erroneous factor from the sps numerator in both `ff_ppo` and `recurrent_ppo`.

## Root cause

`training_epoch_with_timing` times a **single** `training_epoch` (one reset):

```python
t = time.time()
result = training_epoch(...)   # one epoch
...
epoch_training_time = time.time() - t
sps = (num_training_steps_per_epoch * env_step_per_training_step
       * max(num_resets_per_eval, 1)) / epoch_training_time   # <-- bug
```

But the `num_resets_per_eval` loop is **external** to this timed function (in the main training loop: `for _ in range(max(num_resets_per_eval, 1)): training_epoch_with_timing(...)`). So `epoch_training_time` covers one reset's worth of work, while the numerator multiplies by `num_resets_per_eval` — inflating reported SPS by that factor.

This is a brax-inherited formula that was correct when the reset loop lived *inside* the jitted epoch; it became wrong once the loop was hoisted out (so the recurrent hidden state can be reset between resets). It only bites when `num_resets_per_eval > 1`.

## Evidence

Validated against the ground-truth env-step counter (`num_steps_thousands`, which has no reset factor), per-eval:

| Run | `num_resets_per_eval` | Reported SPS | True SPS (Δsteps/Δtrain_walltime) | ratio |
|---|---|---|---|---|
| `eval_every == reset_every` (jax/MJX) | 1 | ~28,430 | ~28,420 | **1.00** |
| `eval_every=150M, reset_every=30M` (warp) | 5 | ~467,000 | ~93,000 | **5.0** |

The ratio equals `num_resets_per_eval` exactly, on every epoch.

## Fix

Drop `* max(num_resets_per_eval, 1)` from the sps numerator only:

```python
sps = (num_training_steps_per_epoch * env_step_per_training_step) / epoch_training_time
```

- Applied identically to `ff_ppo/ppo.py` and `recurrent_ppo/ppo.py`.
- The `num_training_steps_per_epoch` computation keeps the factor (correct — it's in the denominator) and is **unchanged**.
- No other metric is affected (reward/loss/`num_steps_thousands`/walltime are all correct).

## Impact / migration

- Runs configured with `eval_every == reset_every` were already correct (factor 1).
- For finished runs with `num_resets_per_eval > 1`, divide reported `training/sps` by `num_resets_per_eval` to recover true throughput. No retraining needed.

## Verification

- `python -m py_compile` passes on both files.
- `git diff` touches only the two sps numerator blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)