### PR TITLE
Fix value network activation, add histogram logging, improve style compliance and training robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a package for training control policies through motion imitation using d
 
 #### Prerequisites
 
-- Python 3.11 or 3.12
+- Python 3.12
 - [uv](https://docs.astral.sh/uv/) package manager (recommended) or pip
 - CUDA 12.x or 13.x (for GPU support, optional)
 
@@ -37,31 +37,32 @@ pip install uv
 git clone https://github.com/talmolab/track-mjx.git
 cd track-mjx
 ```
-2. Create and activate a virtual environment:
-```bash
-uv venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-```
-3. Install the package with optional dependencies based on your hardware. CUDA 12, CUDA 13, and CPU-only configurations are supported. This will take a few minutes:
+2. Install the environment with optional dependencies based on your hardware.
+`uv sync` creates `.venv` automatically. CUDA 12, CUDA 13, and CPU-only
+configurations are supported:
 
 For CUDA 12.x:
 ```bash
-uv pip install -e ".[cuda12]"
+uv sync --extra cuda12
 ```
 
 For CUDA 13.x:
 ```bash
-uv pip install -e ".[cuda13]"
+uv sync --extra cuda13
 ```
 
 For CPU-only:
 ```bash
-uv pip install -e .
+uv sync
 ```
 
-For development, include the `[dev]` extras in addition to the hardware optional dependencies:
+For development, include the `dev` extra:
 ```bash
-uv pip install -e ".[cuda13,dev]"
+uv sync --extra cuda13 --extra dev
+```
+3. Activate the environment:
+```bash
+source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 ```
 4. Verify the installation:
 ```bash
@@ -155,13 +156,13 @@ python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id=
 
 **Using uv:**
 ```bash
-uv run python -m track_mjx.train --config-name rodent-full-clips.yaml
+uv run python scripts/train.py --config-name rodent-full-clips
 ```
 
 **Using conda:**
 ```bash
 conda activate track_mjx
-python -m track_mjx.train --config-name rodent-full-clips.yaml
+python scripts/train.py --config-name rodent-full-clips
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
     "jax==0.10.2",
     "jaxlib==0.10.2",
-    "brax==0.14.0",
+    "brax==0.14.2",
     "flax==0.12.7",
     "optax==0.2.8",
     "orbax-checkpoint==0.12.0",
@@ -34,7 +34,7 @@ dependencies = [
     "mediapy==1.2.2",
     "imageio[ffmpeg]==2.37.0",
     "hydra-core==1.3.2",
-    "wandb==0.19.5",
+    "wandb==0.28.0",
     "huggingface-hub==1.20.1",
     "jaxtyping>=0.2.34",
     "playground",
@@ -109,8 +109,12 @@ ignore = [
 known-first-party = ["track_mjx"]
 
 [tool.uv.sources]
+brax = { git = "https://github.com/google/brax", rev = "1aa46f127bc4208d0c6de350a58ef00c8f01b0d9" }
 vnl-playground = { git = "https://github.com/talmolab/vnl-playground", rev = "1529ac42d952c41b9408f8bebbb25602f3881ad3" }
 playground = { git = "https://github.com/google-deepmind/mujoco_playground", rev = "b63fcb5db02a0f27aaf2b29ce6fc14c75489fa16" }
+
+[tool.uv]
+override-dependencies = ["brax==0.14.2"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,8 @@ dependencies = [
     "flax==0.12.7",
     "optax==0.2.8",
     "orbax-checkpoint==0.12.0",
-    "mujoco-mjx[warp]==3.10.1",
+    "mujoco==3.8.1",
+    "mujoco-mjx[warp]==3.8.1",
     "PyOpenGL==3.1.9",
     "numpy==2.1.3",
     "h5py==3.12.1",
@@ -115,6 +116,7 @@ playground = { git = "https://github.com/google-deepmind/mujoco_playground", rev
 
 [tool.uv]
 override-dependencies = ["brax==0.14.2"]
+no-sources-package = ["mujoco", "mujoco-mjx"]
 
 [dependency-groups]
 dev = [

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -12,14 +12,15 @@ import logging
 
 import hydra
 import jax
+import numpy as np
 import orbax.checkpoint as ocp
 from brax.training.distribution import NormalTanhDistribution
-from mujoco_playground import wrapper as playground_wrappers
 from omegaconf import DictConfig
 from vnl_playground import registry
 from vnl_playground.tasks import wrappers as rodent_wrappers
 
 import wandb
+from track_mjx import training_wrappers
 from track_mjx.agent import checkpointing, wandb_logging
 from track_mjx.agent.distribution import NormalSigmoidDistribution
 from track_mjx.agent.domain_randomization import domain_randomization_maker
@@ -102,19 +103,24 @@ def main(cfg: DictConfig) -> None:
         env_name,
         data_path=cfg.env_config.reference_data_path,
         n_frames_per_clip=cfg.env_config.clip_length,
-        keep_clips_idx=cfg.env_config.keep_clips_idx,
+        keep_clips_idx=(
+            np.asarray(cfg.env_config.keep_clips_idx)
+            if cfg.env_config.keep_clips_idx is not None
+            else None
+        ),
         joint_names=cfg.env_config.get("joints", default_config.get("joints", None)),
         body_names=cfg.env_config.get("bodies", default_config.get("bodies", None)),
     )
-    key_split, _ = jax.random.split(jax.random.key(cfg.train_setup.train_config.seed))
     train_clips, test_clips = reference_clips.split(
         train_ratio=cfg.train_setup.train_subset_ratio,
-        seed=key_split,
+        seed=int(cfg.train_setup.train_config.seed),
     )
-    logging.info(f"Training on {len(train_clips)} clips: {train_clips}")
-    logging.info(f"Testing on {len(test_clips)} clips: {test_clips}")
+    num_train_clips = int(train_clips.qpos.shape[0])
+    num_test_clips = int(test_clips.qpos.shape[0])
+    logging.info(f"Training on {num_train_clips} clips: {train_clips}")
+    logging.info(f"Testing on {num_test_clips} clips: {test_clips}")
 
-    if len(train_clips) == 0:
+    if num_train_clips == 0:
         raise ValueError(
             f"train_subset_ratio={cfg.train_setup.train_subset_ratio} yields 0 "
             f"training clips. Increase the ratio or add more clips."
@@ -129,7 +135,7 @@ def main(cfg: DictConfig) -> None:
         logging.warning(f"Failed to save environment spec: {e}")
         xml = None
 
-    if len(test_clips) == 0:
+    if num_test_clips == 0:
         logging.warning(
             "No test clips after split — skipping held-out test-set evaluation."
         )
@@ -237,7 +243,7 @@ def main(cfg: DictConfig) -> None:
         eval_env_test_set=test_env,
         checkpoint_callback=checkpoint_callback,
         wrap_for_training=functools.partial(
-            playground_wrappers.wrap_for_brax_training, full_reset=False
+            training_wrappers.wrap_for_brax_training, full_reset=False
         ),
         randomization_fn=(
             domain_randomization_maker(
@@ -266,7 +272,12 @@ def main(cfg: DictConfig) -> None:
     rollout_cfg = env_cfg_ml.copy_and_resolve_references()
     rollout_cfg.start_frame_range = [0, 0]
     rollout_env = rodent_wrappers.TrackMjxObsWrapper(
-        registry.load(env_name, config=rollout_cfg, clips=None, flatten_obs=False)
+        registry.load(
+            env_name,
+            config=rollout_cfg,
+            clips=reference_clips,
+            flatten_obs=False,
+        )
     )
 
     jit_reset = jax.jit(rollout_env.reset)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,13 +13,13 @@ import logging
 import hydra
 import jax
 import orbax.checkpoint as ocp
-import wandb
 from brax.training.distribution import NormalTanhDistribution
 from mujoco_playground import wrapper as playground_wrappers
 from omegaconf import DictConfig
 from vnl_playground import registry
 from vnl_playground.tasks import wrappers as rodent_wrappers
 
+import wandb
 from track_mjx.agent import checkpointing, wandb_logging
 from track_mjx.agent.distribution import NormalSigmoidDistribution
 from track_mjx.agent.domain_randomization import domain_randomization_maker

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -72,6 +72,22 @@ def main(cfg: DictConfig) -> None:
 
     run_id, checkpoint_path, existing_run_state = checkpointing.load_from_run_state(cfg)
 
+    # Initialize wandb early so that clip loading and env creation are visible
+    wandb_logging.initialize_wandb_logging(
+        logging_cfg=cfg.logging_config,
+        cfg=cfg,
+        run_id=run_id,
+        existing_run_state=existing_run_state,
+    )
+
+    if existing_run_state is None:
+        checkpointing.save_run_state(
+            cfg=cfg,
+            run_id=run_id,
+            checkpoint_path=checkpoint_path,
+            wandb_run_id=wandb.run.id,
+        )
+
     mgr_options = ocp.CheckpointManagerOptions(
         create=True,
         step_prefix="PPONetwork",
@@ -97,6 +113,13 @@ def main(cfg: DictConfig) -> None:
     )
     logging.info(f"Training on {len(train_clips)} clips: {train_clips}")
     logging.info(f"Testing on {len(test_clips)} clips: {test_clips}")
+
+    if len(train_clips) == 0:
+        raise ValueError(
+            f"train_subset_ratio={cfg.train_setup.train_subset_ratio} yields 0 "
+            f"training clips. Increase the ratio or add more clips."
+        )
+
     env = rodent_wrappers.TrackMjxObsWrapper(
         registry.load(env_name, config=env_cfg_ml, clips=train_clips, flatten_obs=False)
     )
@@ -105,9 +128,18 @@ def main(cfg: DictConfig) -> None:
     except Exception as e:
         logging.warning(f"Failed to save environment spec: {e}")
         xml = None
-    test_env = rodent_wrappers.TrackMjxObsWrapper(
-        registry.load(env_name, config=env_cfg_ml, clips=test_clips, flatten_obs=False)
-    )
+
+    if len(test_clips) == 0:
+        logging.warning(
+            "No test clips after split — skipping held-out test-set evaluation."
+        )
+        test_env = None
+    else:
+        test_env = rodent_wrappers.TrackMjxObsWrapper(
+            registry.load(
+                env_name, config=env_cfg_ml, clips=test_clips, flatten_obs=False
+            )
+        )
 
     logging.info(f"Environment config: {cfg.env_config}")
     logging.info(f"Train environment: {env.unwrapped}")
@@ -178,22 +210,8 @@ def main(cfg: DictConfig) -> None:
         )
         ppo_module = ff_ppo
 
-    wandb_logging.initialize_wandb_logging(
-        logging_cfg=cfg.logging_config,
-        cfg=cfg,
-        run_id=run_id,
-        existing_run_state=existing_run_state,
-    )
     if xml is not None:
         wandb.log({"spec_file": wandb.Html(xml)}, commit=False)
-
-    if existing_run_state is None:
-        checkpointing.save_run_state(
-            cfg=cfg,
-            run_id=run_id,
-            checkpoint_path=checkpoint_path,
-            wandb_run_id=wandb.run.id,
-        )
 
     checkpoint_callback = checkpointing.create_checkpoint_callback(
         cfg=cfg,

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -14,12 +14,12 @@ import hydra
 import jax
 import numpy as np
 import orbax.checkpoint as ocp
+import wandb
 from brax.training.distribution import NormalTanhDistribution
 from omegaconf import DictConfig
 from vnl_playground import registry
 from vnl_playground.tasks import wrappers as rodent_wrappers
 
-import wandb
 from track_mjx import training_wrappers
 from track_mjx.agent import checkpointing, wandb_logging
 from track_mjx.agent.distribution import NormalSigmoidDistribution

--- a/scripts/train_highlvl.py
+++ b/scripts/train_highlvl.py
@@ -47,8 +47,8 @@ from typing import Any
 
 import hydra
 import jax
-
 import wandb
+
 from track_mjx.device_utils import enable_jit_cache
 
 enable_jit_cache()

--- a/scripts/train_highlvl.py
+++ b/scripts/train_highlvl.py
@@ -47,17 +47,15 @@ from typing import Any
 
 import hydra
 import jax
+
 import wandb
+from track_mjx.device_utils import enable_jit_cache
 
-from track_mjx.device_utils import enable_jit_cache, patch_brax_pmap_compat
-
-patch_brax_pmap_compat()
 enable_jit_cache()
 from brax.training.acme import running_statistics
 from brax.training.agents.ppo import networks as ppo_networks
 from brax.training.agents.ppo import train as ppo
 from etils import epath
-from mujoco_playground import wrapper
 from omegaconf import OmegaConf
 from utils import (
     apply_env_overrides,
@@ -72,12 +70,9 @@ from utils import (
 from vnl_playground import registry
 from vnl_playground.tasks import wrappers as rodent_wrappers
 
+from track_mjx import training_wrappers
 from track_mjx.agent import checkpointing
 from track_mjx.agent.ff_ppo import ppo_networks as ff_ppo_networks
-from track_mjx.device_utils import enable_jit_cache, patch_brax_pmap_compat
-
-patch_brax_pmap_compat()
-enable_jit_cache()
 
 
 def load_mimic_checkpoint(checkpoint_path: str) -> tuple:
@@ -263,7 +258,7 @@ def main():
         network_factory=network_factory,
         restore_checkpoint_path=None,
         progress_fn=wandb_progress,
-        wrap_env_fn=functools.partial(wrapper.wrap_for_brax_training),
+        wrap_env_fn=functools.partial(training_wrappers.wrap_for_brax_training),
     )
 
     # Setup logging

--- a/scripts/train_highlvl.py
+++ b/scripts/train_highlvl.py
@@ -42,6 +42,7 @@ os.environ["PYOPENGL_PLATFORM"] = "egl"
 import functools
 import json
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 import hydra
@@ -81,7 +82,7 @@ enable_jit_cache()
 
 def load_mimic_checkpoint(checkpoint_path: str) -> tuple:
     """Load mimic checkpoint config and decoder policy."""
-    if os.path.isabs(checkpoint_path):
+    if Path(checkpoint_path).is_absolute():
         full_path = checkpoint_path
     else:
         full_path = hydra.utils.to_absolute_path(

--- a/scripts/train_task.py
+++ b/scripts/train_task.py
@@ -41,8 +41,8 @@ import json
 from datetime import datetime
 
 import jax
-
 import wandb
+
 from track_mjx.device_utils import enable_jit_cache
 
 enable_jit_cache()

--- a/scripts/train_task.py
+++ b/scripts/train_task.py
@@ -41,17 +41,15 @@ import json
 from datetime import datetime
 
 import jax
+
 import wandb
+from track_mjx.device_utils import enable_jit_cache
 
-from track_mjx.device_utils import enable_jit_cache, patch_brax_pmap_compat
-
-patch_brax_pmap_compat()
 enable_jit_cache()
 from brax.training.acme import running_statistics
 from brax.training.agents.ppo import networks as ppo_networks
 from brax.training.agents.ppo import train as ppo
 from etils import epath
-from mujoco_playground import wrapper
 from utils import (
     apply_env_overrides,
     configure_warp_backend,
@@ -65,10 +63,7 @@ from utils import (
 from vnl_playground import registry
 from vnl_playground.tasks import wrappers as rodent_wrappers
 
-from track_mjx.device_utils import enable_jit_cache, patch_brax_pmap_compat
-
-patch_brax_pmap_compat()
-enable_jit_cache()
+from track_mjx import training_wrappers
 
 
 def create_environments(task_name, env_cfg):
@@ -195,7 +190,7 @@ def main():
         network_factory=network_factory,
         restore_checkpoint_path=None,
         progress_fn=wandb_progress,
-        wrap_env_fn=functools.partial(wrapper.wrap_for_brax_training),
+        wrap_env_fn=functools.partial(training_wrappers.wrap_for_brax_training),
     )
 
     # Setup logging

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -7,12 +7,13 @@ from typing import Any
 import imageio
 import jax
 import jax.numpy as jp
-import wandb
 from etils import epath
 from flax.training import orbax_utils
 from ml_collections import config_dict
 from orbax import checkpoint as ocp
 from vnl_playground.tasks.rodent import consts
+
+import wandb
 
 
 def parse_value(value_str: str) -> Any:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -7,13 +7,12 @@ from typing import Any
 import imageio
 import jax
 import jax.numpy as jp
+import wandb
 from etils import epath
 from flax.training import orbax_utils
 from ml_collections import config_dict
 from orbax import checkpoint as ocp
 from vnl_playground.tasks.rodent import consts
-
-import wandb
 
 
 def parse_value(value_str: str) -> Any:

--- a/track_mjx/__init__.py
+++ b/track_mjx/__init__.py
@@ -1,7 +1,6 @@
 """This module exposes all high level APIs for track-mjx"""
 
-from track_mjx.device_utils import enable_jit_cache, patch_brax_pmap_compat
+from track_mjx.device_utils import enable_jit_cache
 from track_mjx.version import __version__ as __version__
 
 enable_jit_cache()
-patch_brax_pmap_compat()

--- a/track_mjx/agent/checkpointing.py
+++ b/track_mjx/agent/checkpointing.py
@@ -893,7 +893,7 @@ def load_from_run_state(
             cfg.train_setup.train_config.num_timesteps = submitted_timesteps
 
         checkpoint_path = checkpoint_to_restore
-        run_id = os.path.basename(checkpoint_path)
+        run_id = Path(checkpoint_path).name
 
     logging.info(f"Run ID: {run_id}")
     logging.info(f"Training checkpoint path: {checkpoint_path}")

--- a/track_mjx/agent/checkpointing.py
+++ b/track_mjx/agent/checkpointing.py
@@ -173,6 +173,30 @@ def load_training_state(
         )["train_state"]
 
 
+def restore_env_steps(ckpt_mgr: ocp.CheckpointManager, step: int) -> int:
+    """Restore the exact host-side environment-step count."""
+    progress = ckpt_mgr.restore(
+        step,
+        args=ocp.args.Composite(progress=ocp.args.JsonRestore()),
+    )["progress"]
+    return int(progress["env_steps"])
+
+
+def load_env_steps(
+    checkpoint_path: str,
+    step_prefix: str = "PPONetwork",
+    step: int | None = None,
+) -> int:
+    """Load the exact environment-step count from a checkpoint directory."""
+    mgr_options = ocp.CheckpointManagerOptions(create=False, step_prefix=step_prefix)
+    with ocp.CheckpointManager(checkpoint_path, options=mgr_options) as ckpt_mgr:
+        if step is None:
+            step = ckpt_mgr.latest_step()
+        if step is None:
+            raise ValueError(f"No checkpoints found in {checkpoint_path}")
+        return restore_env_steps(ckpt_mgr, step)
+
+
 def load_policy(
     checkpoint_path: str,
     cfg: DictConfig | None = None,
@@ -530,6 +554,7 @@ def save(
     policy: tuple[Any, Any],
     training_state: Any,
     config: dict[str, Any],
+    env_steps: int,
     checkpoint_callback: Callable[[int], None] | None = None,
 ) -> None:
     """Save a training checkpoint.
@@ -543,6 +568,7 @@ def save(
         policy: Policy parameters (normalizer_state, policy_params).
         training_state: Full training state for resumption.
         config: Configuration dictionary.
+        env_steps: Exact host-side environment-step count.
         checkpoint_callback: Optional callback called with step after save.
     """
     ckpt_mgr.save(
@@ -551,6 +577,7 @@ def save(
             policy=ocp.args.StandardSave(policy),
             train_state=ocp.args.StandardSave(training_state),
             config=ocp.args.JsonSave(config),
+            progress=ocp.args.JsonSave({"env_steps": int(env_steps)}),
         ),
     )
 

--- a/track_mjx/agent/distribution.py
+++ b/track_mjx/agent/distribution.py
@@ -1,22 +1,43 @@
-"""Extra parametric action distributions not implemented in brax.training.distribution"""
+"""Extra parametric action distributions not in ``brax.training.distribution``.
+
+Provides a sigmoid-bounded normal distribution and its associated bijector,
+adapted from TensorFlow Probability's Sigmoid bijector for numerical stability.
+"""
 
 import jax
 import jax.numpy as jnp
 from brax.training import distribution
 
+_CUTOFF_F64 = -20
+_CUTOFF_F32 = -9
+
 
 def _stable_sigmoid(x):
-    """A (more) numerically stable sigmoid than `jax.nn.sigmoid`. Implemented based on `tensorflow.distributions.bijectors.Sigmoid`"""
+    """Numerically stable sigmoid, falling back to exp(x) for very negative inputs.
+
+    Args:
+        x: Input array.
+
+    Returns:
+        Sigmoid of x with improved numerical stability for large negative values.
+    """
     x = jnp.asarray(x)
-    cutoff = -20 if x.dtype == jnp.float64 else -9
+    cutoff = _CUTOFF_F64 if x.dtype == jnp.float64 else _CUTOFF_F32
     return jnp.where(x < cutoff, jnp.exp(x), jax.nn.sigmoid(x))
 
 
 @jax.custom_gradient
 def _stable_grad_softplus(x):
-    """A (more) numerically stable softplus than `jax.nn.softplus`. Implemented based on `tensorflow.distributions.bijectors.Sigmoid`"""
+    """Numerically stable softplus with a custom gradient for large negative inputs.
+
+    Args:
+        x: Input array.
+
+    Returns:
+        Softplus of x with correct gradients for values below the stability cutoff.
+    """
     x = jnp.asarray(x)
-    cutoff = -20 if x.dtype == jnp.float64 else -9
+    cutoff = _CUTOFF_F64 if x.dtype == jnp.float64 else _CUTOFF_F32
 
     y = jnp.where(x < cutoff, jnp.log1p(jnp.exp(x)), jax.nn.softplus(x))
 
@@ -27,7 +48,15 @@ def _stable_grad_softplus(x):
 
 
 class SigmoidBijector:
-    """Sigmoid Bijector. Implemented based on `tensorflow.distributions.bijectors.Sigmoid`."""
+    """Sigmoid bijector mapping reals to ``[low, high]``.
+
+    Adapted from ``tensorflow.distributions.bijectors.Sigmoid`` with
+    numerically stable forward, inverse, and log-det-jacobian computations.
+
+    Args:
+        low: Lower bound of the output range.
+        high: Upper bound of the output range.
+    """
 
     def __init__(self, low=0.0, high=1.0):
         self.low = low
@@ -35,9 +64,10 @@ class SigmoidBijector:
         self._is_standard_sigmoid = low == 0.0 and high == 1.0
 
     def forward(self, x):
+        """Map unconstrained input to ``[low, high]``."""
         if self._is_standard_sigmoid:
             return _stable_sigmoid(x)
-        lo = jnp.asarray(self.low)  # Concretize only once
+        lo = jnp.asarray(self.low)
         hi = jnp.asarray(self.high)
         diff = hi - lo
         left = lo + diff * _stable_sigmoid(x)
@@ -45,11 +75,13 @@ class SigmoidBijector:
         return jnp.where(x < 0, left, right)
 
     def inverse(self, y):
+        """Map bounded value back to unconstrained space."""
         if self._is_standard_sigmoid:
             return jnp.log(y) - jnp.log1p(-y)
         return jnp.log(y - self.low) - jnp.log(self.high - y)
 
     def forward_log_det_jacobian(self, x):
+        """Log absolute determinant of the Jacobian of ``forward``."""
         sigmoid_fldj = -_stable_grad_softplus(-x) - _stable_grad_softplus(x)
         if self._is_standard_sigmoid:
             return sigmoid_fldj

--- a/track_mjx/agent/domain_randomization.py
+++ b/track_mjx/agent/domain_randomization.py
@@ -12,13 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""Domain randomization for the Go1 environment."""
+"""Domain randomization for MuJoCo MJX environments.
+
+Applies per-environment physics randomization (friction, mass, armature, etc.)
+to improve sim-to-sim and sim-to-real transfer. Currently uses hardcoded geom
+and body indices for the rodent model.
+"""
 
 import jax
 from mujoco import mjx
 
 FLOOR_GEOM_ID = 1
 TORSO_BODY_ID = 3
+
+FREE_JOINT_DOFS = 6
+FREE_JOINT_QPOS = 7
 
 
 def domain_randomization_maker(
@@ -30,12 +38,29 @@ def domain_randomization_maker(
     torso_mass_jitter: tuple[float, float] = (-0.02, 0.02),
     qpos0_jitter: tuple[float, float] = (-0.05, 0.05),
 ):
+    """Create a domain randomization function for MJX environments.
+
+    Returns a function compatible with Brax's ``randomization_fn`` interface
+    that randomizes physics parameters per-environment using ``jax.vmap``.
+
+    Args:
+        floor_friction: (min, max) range for uniform floor friction sampling.
+        static_friction_scale: (min, max) multiplicative scale for DOF frictionloss.
+        armature_scale: (min, max) multiplicative scale for DOF armature.
+        com_jitter: (min, max) additive jitter for torso center of mass position.
+        link_mass_scale: (min, max) multiplicative scale for all body masses.
+        torso_mass_jitter: (min, max) additive jitter for torso mass.
+        qpos0_jitter: (min, max) additive jitter for initial joint positions.
+
+    Returns:
+        A function ``(model, rng) -> (model, in_axes)`` that applies randomized
+        dynamics and returns the per-axis vmap specification.
+    """
 
     def domain_randomize(model: mjx.Model, rng: jax.Array):
         @jax.vmap
         def rand_dynamics(rng):
-            # Get the number of actuated joints
-            n_actuated = model.nv - 6  # Total DOFs minus free joints
+            n_actuated = model.nv - FREE_JOINT_DOFS
 
             # Floor friction: =U(0.4, 1.0).
             rng, key = jax.random.split(rng)
@@ -47,23 +72,27 @@ def domain_randomization_maker(
 
             # Scale static friction: *U(0.9, 1.1).
             rng, key = jax.random.split(rng)
-            frictionloss = model.dof_frictionloss[6:] * jax.random.uniform(
+            frictionloss = model.dof_frictionloss[
+                FREE_JOINT_DOFS:
+            ] * jax.random.uniform(
                 key,
                 shape=(n_actuated,),
                 minval=static_friction_scale[0],
                 maxval=static_friction_scale[1],
             )
-            dof_frictionloss = model.dof_frictionloss.at[6:].set(frictionloss)
+            dof_frictionloss = model.dof_frictionloss.at[FREE_JOINT_DOFS:].set(
+                frictionloss
+            )
 
             # Scale armature: *U(1.0, 1.05).
             rng, key = jax.random.split(rng)
-            armature = model.dof_armature[6:] * jax.random.uniform(
+            armature = model.dof_armature[FREE_JOINT_DOFS:] * jax.random.uniform(
                 key,
                 shape=(n_actuated,),
                 minval=armature_scale[0],
                 maxval=armature_scale[1],
             )
-            dof_armature = model.dof_armature.at[6:].set(armature)
+            dof_armature = model.dof_armature.at[FREE_JOINT_DOFS:].set(armature)
 
             # Jitter center of mass positiion: +U(-0.05, 0.05).
             rng, key = jax.random.split(rng)
@@ -96,8 +125,8 @@ def domain_randomization_maker(
             # Jitter qpos0: +U(-0.05, 0.05).
             rng, key = jax.random.split(rng)
             qpos0 = model.qpos0
-            qpos0 = qpos0.at[7:].set(
-                qpos0[7:]
+            qpos0 = qpos0.at[FREE_JOINT_QPOS:].set(
+                qpos0[FREE_JOINT_QPOS:]
                 + jax.random.uniform(
                     key,
                     shape=(n_actuated,),

--- a/track_mjx/agent/ff_ppo/intention_network.py
+++ b/track_mjx/agent/ff_ppo/intention_network.py
@@ -27,6 +27,7 @@ from flax import linen as nn
 from track_mjx.agent.observation_utils import (
     normalizer_select,
 )
+from track_mjx.random_utils import sample_normal, split_prng_key
 
 
 class Encoder(nn.Module):
@@ -120,38 +121,13 @@ class Decoder(nn.Module):
         return x, {}
 
 
-def reparameterize_single(
-    rng: jax.Array, mean: jnp.ndarray, logvar: jnp.ndarray
-) -> jnp.ndarray:
-    """Sample from Gaussian using reparameterization trick (single sample).
-
-    Enables backpropagation through stochastic sampling by expressing the
-    sample as a deterministic function of the parameters plus noise.
-
-    Args:
-        rng: JAX random key for sampling (shape [2]).
-        mean: Mean of the Gaussian distribution (shape [latent_dim]).
-        logvar: Log-variance of the Gaussian distribution (shape [latent_dim]).
-
-    Returns:
-        Sampled latent vector: mean + std * epsilon, where epsilon ~ N(0, I).
-    """
-    std = jnp.exp(0.5 * logvar)
-    eps = jax.random.normal(rng, logvar.shape)
-    return mean + eps * std
-
-
 def reparameterize(
     rng: jax.Array, mean: jnp.ndarray, logvar: jnp.ndarray
 ) -> jnp.ndarray:
     """Sample from Gaussian using reparameterization trick (batched).
 
-    Supports both single key (broadcasted) and per-sample keys for
-    deterministic replay.
-
     Args:
-        rng: JAX random key(s) for sampling. Either shape [2] (single key
-            for all samples) or [batch_size, 2] (per-sample keys).
+        rng: Scalar typed key or typed key batch with shape [batch_size].
         mean: Mean of the Gaussian distribution, shape [latent_dim] (unbatched)
             or [batch_size, latent_dim] (batched).
         logvar: Log-variance of the Gaussian distribution, same shape as mean.
@@ -159,18 +135,8 @@ def reparameterize(
     Returns:
         Sampled latent vectors with same shape as mean.
     """
-    if rng.ndim == 1:
-        # Single key - use original behavior
-        std = jnp.exp(0.5 * logvar)
-        eps = jax.random.normal(rng, logvar.shape)
-        return mean + eps * std
-    elif mean.ndim == 1:
-        # Per-sample keys but unbatched mean/logvar - use first key
-        # This is a fallback safety for shape mismatches
-        return reparameterize_single(rng[0], mean, logvar)
-    else:
-        # Per-sample keys with batched mean/logvar - vmap over batch dimension
-        return jax.vmap(reparameterize_single)(rng, mean, logvar)
+    std = jnp.exp(0.5 * logvar)
+    return mean + sample_normal(rng, logvar) * std
 
 
 class IntentionNetwork(nn.Module):
@@ -209,31 +175,10 @@ class IntentionNetwork(nn.Module):
         traj = obs["task_obs"]
         egocentric_obs = obs["proprioception"]
 
-        # Check if observations are actually batched (based on normalized obs shape)
-        obs_is_batched = traj.ndim >= 2
-
-        # Handle key splitting based on both key shape AND observation shape
-        if key.ndim == 1:
-            # Single key - split for encoder
-            encoder_rng, noise_rng = jax.random.split(key)
-        elif not obs_is_batched:
-            # Per-sample keys but unbatched observation - use first key
-            # This can happen when key batching was determined from nested obs structure
-            # before normalization flattened it to unbatched
-            encoder_rng, noise_rng = jax.random.split(key[0])
-        else:
-            # Per-sample keys [batch_size, 2] - vmap split over batch
-            encoder_rng, noise_rng = jax.vmap(jax.random.split)(key).swapaxes(0, 1)
+        encoder_rng, noise_rng = split_prng_key(key)
 
         if not deterministic and self.proprioception_noise_std > 0.0:
-            if noise_rng.ndim == 1:
-                noise = jax.random.normal(noise_rng, egocentric_obs.shape)
-            elif not obs_is_batched:
-                noise = jax.random.normal(noise_rng[0], egocentric_obs.shape)
-            else:
-                noise = jax.vmap(
-                    lambda rng_key, obs_i: jax.random.normal(rng_key, obs_i.shape)
-                )(noise_rng, egocentric_obs)
+            noise = sample_normal(noise_rng, egocentric_obs)
             egocentric_obs = egocentric_obs * (
                 1.0 + self.proprioception_noise_std * noise
             )

--- a/track_mjx/agent/ff_ppo/losses.py
+++ b/track_mjx/agent/ff_ppo/losses.py
@@ -239,7 +239,7 @@ def compute_ppo_loss(
         )
     else:
         # Deterministic replay: use stored per-sample RNGs
-        # policy_rng has shape [T, B, 2] after swapaxes
+        # policy_rng has shape [T, B] after swapaxes for typed keys.
         # data.observation is a dict where each leaf has shape [T, B, obs_dim]
         # Flatten [T, B] into single batch dim to avoid vmap (better for buffer donation)
         obs_leaf = jax.tree.leaves(data.observation)[0]
@@ -250,8 +250,8 @@ def compute_ppo_loss(
             lambda x: x.reshape((T * B, *x.shape[2:])),
             data.observation,
         )
-        # Flatten keys [T, B, 2] -> [T*B, 2]
-        flat_rng = policy_rng.reshape((T * B, 2))
+        # Flatten typed keys [T, B] -> [T*B].
+        flat_rng = policy_rng.reshape(-1)
 
         # Single call with combined batch (policy handles per-sample keys natively)
         flat_logits, flat_mean, flat_logvar = policy_apply(

--- a/track_mjx/agent/ff_ppo/ppo.py
+++ b/track_mjx/agent/ff_ppo/ppo.py
@@ -42,22 +42,19 @@ from brax.training.acme import running_statistics
 from brax.training.types import Params, PRNGKey
 from mujoco_playground import wrapper as mp_wrapper
 
+from track_mjx import training_wrappers
 from track_mjx.agent import checkpointing, gradients
 from track_mjx.agent.ff_ppo import losses, ppo_networks
 from track_mjx.agent.observation_utils import (
     get_obs_shape,
     get_obs_sizes,
 )
-from track_mjx.device_utils import patch_brax_pmap_compat, replicate_for_pmap
-
-patch_brax_pmap_compat()
 
 # Type aliases
 InferenceParams = tuple[running_statistics.RunningStatisticsState, Params]
 Metrics = types.Metrics
 
 # Constants
-STEPS_IN_THOUSANDS = 1e3
 _PMAP_AXIS_NAME = "i"
 
 
@@ -70,13 +67,11 @@ class TrainingState:
         params: PPO network parameters (policy and value).
         normalizer_params: Running statistics for observation normalization.
             Has pytree structure matching observation dict.
-        env_steps: Total environment steps taken (in thousands).
     """
 
     optimizer_state: optax.OptState
     params: losses.PPONetworkParams
     normalizer_params: running_statistics.RunningStatisticsState
-    env_steps: jnp.ndarray
 
 
 def _unpmap(v: Any) -> Any:
@@ -88,7 +83,7 @@ def _unpmap(v: Any) -> Any:
     Returns:
         Pytree with device axis removed (values from first device).
     """
-    return jax.tree.map(lambda x: x[0], v)
+    return jax.tree.map(lambda x: x.addressable_shards[0].data.squeeze(0), v)
 
 
 def _strip_weak_type(tree: Any) -> Any:
@@ -106,6 +101,8 @@ def _strip_weak_type(tree: Any) -> Any:
 
     def f(leaf):
         leaf = jnp.asarray(leaf)
+        if jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
+            return leaf
         return leaf.astype(leaf.dtype)
 
     return jax.tree.map(f, tree)
@@ -231,7 +228,7 @@ def train(
     checkpoint_callback: Callable[[int], None] | None = None,
     grad_clip_threshold: float = 20.0,
     wrap_for_training: Callable[..., mp_wrapper.Wrapper] = functools.partial(
-        mp_wrapper.wrap_for_brax_training, full_reset=False
+        training_wrappers.wrap_for_brax_training, full_reset=False
     ),
 ) -> tuple[Callable, InferenceParams, Metrics]:
     """Train a PPO agent on the given environment.
@@ -343,6 +340,9 @@ def train(
             * max(num_resets_per_eval, 1)
         )
     ).astype(int)
+    env_steps_per_training_epoch = int(
+        num_training_steps_per_epoch * env_step_per_training_step
+    )
 
     def minibatch_step(
         carry,
@@ -442,11 +442,6 @@ def train(
             optimizer_state=optimizer_state,
             params=params,
             normalizer_params=normalizer_params,
-            env_steps=jnp.asarray(
-                training_state.env_steps
-                + env_step_per_training_step / STEPS_IN_THOUSANDS,
-                dtype=jnp.int32,
-            ),  # env step in thousands
         )
         return (new_training_state, state, new_key, it), metrics
 
@@ -475,7 +470,7 @@ def train(
         nonlocal training_walltime
         t = time.time()
         training_state, env_state = _strip_weak_type((training_state, env_state))
-        step = jnp.ones_like(training_state.env_steps) * it
+        step = jnp.full((local_devices_to_use,), it, dtype=jnp.int32)
         result = training_epoch(training_state, env_state, key, step)
         training_state, env_state, metrics = _strip_weak_type(result)
 
@@ -614,14 +609,15 @@ def train(
         optimizer_state=optimizer.init(init_params),
         params=init_params,
         normalizer_params=running_statistics.init_state(obs_shape),
-        env_steps=0,
     )
 
     # Load the checkpoint if it exists
+    current_step = 0
     if checkpoint_to_restore is not None:
         training_state = checkpointing.load_training_state(
             checkpoint_to_restore, training_state
         )
+        current_step = checkpointing.load_env_steps(checkpoint_to_restore)
         logging.info(f"Restored latest checkpoint at {checkpoint_to_restore}")
 
     # gradient update function with the new optimizer and loss function
@@ -633,8 +629,7 @@ def train(
         clip_threshold=grad_clip_threshold,
     )
 
-    devices = jax.local_devices()[:local_devices_to_use]
-    training_state = replicate_for_pmap(training_state, devices)
+    training_state = pmap.bcast_local_devices(training_state, local_devices_to_use)
 
     if eval_env is None:
         eval_env = environment
@@ -679,8 +674,10 @@ def train(
     # Logic to restore iteration count from checkpoint
     start_it = 0
     if ckpt_mgr is not None and ckpt_mgr.latest_step() is not None:
-        num_evals_after_init -= ckpt_mgr.latest_step()
-        start_it = ckpt_mgr.latest_step()
+        latest_step = ckpt_mgr.latest_step()
+        num_evals_after_init -= latest_step
+        start_it = latest_step
+        current_step = checkpointing.restore_env_steps(ckpt_mgr, latest_step)
 
     logging.info(
         f"Starting at iteration: {start_it} with {num_evals_after_init} evals left"
@@ -709,28 +706,21 @@ def train(
         # Save checkpoints
         logging.info("Saving initial checkpoint")
         if ckpt_mgr is not None:
-            # new orbax API
-            ckpt_mgr.save(
-                step=0,
-                args=ocp.args.Composite(
-                    policy=ocp.args.StandardSave(policy_param),
-                    train_state=ocp.args.StandardSave(_unpmap(training_state)),
-                    config=ocp.args.JsonSave(config_dict),
-                ),
+            checkpointing.save(
+                ckpt_mgr,
+                0,
+                policy_param,
+                _unpmap(training_state),
+                config_dict,
+                current_step,
+                checkpoint_callback,
             )
-            # Call checkpoint callback for initial save
-            if checkpoint_callback is not None:
-                try:
-                    checkpoint_callback(0)
-                except Exception as e:
-                    logging.warning(f"Initial checkpoint callback failed: {e}")
         else:
             logging.info("Skipping checkpoint save as ckpt_mgr is None")
 
     training_metrics = {}
     training_walltime = 0
     start_it += 1
-    current_step = 0
     for it in range(start_it, num_evals_after_init + start_it):
         logging.info("starting iteration %s %s", it, time.time() - xt)
         for _ in range(max(num_resets_per_eval, 1)):
@@ -740,7 +730,7 @@ def train(
             training_state, env_state, training_metrics = training_epoch_with_timing(
                 training_state, env_state, epoch_keys, it
             )
-            current_step = int(_unpmap(training_state.env_steps))
+            current_step += env_steps_per_training_epoch
 
             key_envs = jax.vmap(
                 lambda x, s: jax.random.split(x[0], s), in_axes=(0, None)
@@ -803,13 +793,14 @@ def train(
                     policy_param,
                     _unpmap(training_state),
                     config_dict,
+                    current_step,
                     checkpoint_callback,
                 )
 
     total_steps = current_step
     # TODO: this assert will fail
     # assert (
-    #     total_steps >= num_timesteps / STEPS_IN_THOUSANDS
+    #     total_steps >= num_timesteps
     # ), "Total steps must be at least the number of timesteps scaled to thousands."
 
     # If there was no mistakes the training_state should still be identical on all

--- a/track_mjx/agent/ff_ppo/ppo_networks.py
+++ b/track_mjx/agent/ff_ppo/ppo_networks.py
@@ -26,6 +26,7 @@ import jax
 from brax.training import distribution, networks, types
 from brax.training.acme import running_statistics
 from brax.training.types import PRNGKey
+from flax import linen as nn
 from jax import numpy as jnp
 
 from track_mjx.agent import checkpointing
@@ -279,6 +280,7 @@ def make_intention_ppo_networks(
         obs_sizes=obs_sizes,
         hidden_layer_sizes=value_hidden_layer_sizes,
         value_obs_key=value_obs_key,
+        activation=nn.silu,
     )
 
     return PPOImitationNetworks(

--- a/track_mjx/agent/ff_ppo/ppo_networks.py
+++ b/track_mjx/agent/ff_ppo/ppo_networks.py
@@ -26,7 +26,6 @@ import jax
 from brax.training import distribution, networks, types
 from brax.training.acme import running_statistics
 from brax.training.types import PRNGKey
-from flax import linen as nn
 from jax import numpy as jnp
 
 from track_mjx.agent import checkpointing
@@ -280,7 +279,6 @@ def make_intention_ppo_networks(
         obs_sizes=obs_sizes,
         hidden_layer_sizes=value_hidden_layer_sizes,
         value_obs_key=value_obs_key,
-        activation=nn.silu,
     )
 
     return PPOImitationNetworks(

--- a/track_mjx/agent/gradients.py
+++ b/track_mjx/agent/gradients.py
@@ -26,6 +26,19 @@ def loss_and_pgrad(
     pmap_axis_name: str | None,
     has_aux: bool = False,
 ):
+    """Compute loss value and gradient, averaging gradients across pmap devices.
+
+    Args:
+        loss_fn: Scalar loss function to differentiate.
+        pmap_axis_name: Name of the pmap axis for ``pmean`` gradient sync.
+            If None, returns unsynced gradients (single-device path).
+        has_aux: Whether ``loss_fn`` returns ``(loss, aux)`` instead of ``loss``.
+
+    Returns:
+        A function with the same signature as ``loss_fn`` that returns
+        ``(value, grad)``, where gradients are averaged across devices when
+        ``pmap_axis_name`` is provided.
+    """
     g = jax.value_and_grad(loss_fn, has_aux=has_aux)
 
     def h(*args, **kwargs):

--- a/track_mjx/agent/networks.py
+++ b/track_mjx/agent/networks.py
@@ -5,12 +5,14 @@ from collections.abc import Mapping, Sequence
 import jax.numpy as jnp
 from brax.training import networks
 from brax.training.acme import running_statistics
+from flax import linen as nn
 
 
 def make_dict_value_network(
     obs_sizes: Mapping[str, int],
     hidden_layer_sizes: Sequence[int] = (1024,) * 2,
     value_obs_key: str = "state",
+    activation: networks.ActivationFn = nn.silu,
 ) -> networks.FeedForwardNetwork:
     """Create a value network that accepts nested dictionary observations.
 
@@ -21,6 +23,8 @@ def make_dict_value_network(
         obs_sizes: Dict with 'task_obs' and 'proprioception' sizes.
         hidden_layer_sizes: MLP layer sizes for value network.
         value_obs_key: Top-level observation key for value network.
+        activation: Activation function for hidden layers. Defaults to SiLU
+            to match the policy network activation.
 
     Returns:
         FeedForwardNetwork that accepts nested dict observations.
@@ -38,4 +42,5 @@ def make_dict_value_network(
         preprocess_observations_fn=preprocess,
         hidden_layer_sizes=hidden_layer_sizes,
         obs_key=value_obs_key,
+        activation=activation,
     )

--- a/track_mjx/agent/networks.py
+++ b/track_mjx/agent/networks.py
@@ -12,7 +12,7 @@ def make_dict_value_network(
     obs_sizes: Mapping[str, int],
     hidden_layer_sizes: Sequence[int] = (1024,) * 2,
     value_obs_key: str = "state",
-    activation: networks.ActivationFn = nn.silu,
+    activation: networks.ActivationFn = nn.relu,
 ) -> networks.FeedForwardNetwork:
     """Create a value network that accepts nested dictionary observations.
 
@@ -23,8 +23,8 @@ def make_dict_value_network(
         obs_sizes: Dict with 'task_obs' and 'proprioception' sizes.
         hidden_layer_sizes: MLP layer sizes for value network.
         value_obs_key: Top-level observation key for value network.
-        activation: Activation function for hidden layers. Defaults to SiLU
-            to match the policy network activation.
+        activation: Activation function for hidden layers. Defaults to ReLU
+            to match Brax's previous implicit default.
 
     Returns:
         FeedForwardNetwork that accepts nested dict observations.

--- a/track_mjx/agent/recurrent_ppo/networks.py
+++ b/track_mjx/agent/recurrent_ppo/networks.py
@@ -35,9 +35,13 @@ from brax.training.distribution import NormalTanhDistribution
 from brax.training.types import PRNGKey
 from flax import linen as nn
 
-from track_mjx.agent.ff_ppo.intention_network import Encoder, reparameterize
+from track_mjx.agent.ff_ppo.intention_network import (
+    Encoder,
+    reparameterize,
+)
 from track_mjx.agent.networks import make_dict_value_network
 from track_mjx.agent.observation_utils import normalizer_select
+from track_mjx.random_utils import sample_normal, split_prng_key
 
 # Type aliases
 RNNCellType = Literal["simple", "gru", "lstm"]
@@ -262,9 +266,7 @@ class RecurrentIntentionNetwork(nn.Module):
             obs: Inner observation dict (already selected and normalized):
                 {'task_obs': ..., 'proprioception': ...}
             hidden: RNN hidden state(s) from previous timestep.
-            key: JAX random key for sampling. Either shape [2] (single key
-                for all samples) or [batch_size, 2] (per-sample keys for
-                deterministic replay).
+            key: Scalar typed key or typed key batch with shape [batch_size].
             deterministic: If True, use latent mean instead of sampling.
             get_activation: If True, return activations dict as 5th element.
 
@@ -277,29 +279,10 @@ class RecurrentIntentionNetwork(nn.Module):
         traj = obs["task_obs"]
         egocentric_obs = obs["proprioception"]
 
-        # Check if observations are actually batched (based on obs shape)
-        obs_is_batched = traj.ndim >= 2
-
-        # Handle key splitting based on both key shape AND observation shape
-        if key.ndim == 1:
-            # Single key - split for encoder
-            encoder_rng, noise_rng = jax.random.split(key)
-        elif not obs_is_batched:
-            # Per-sample keys but unbatched observation - use first key
-            encoder_rng, noise_rng = jax.random.split(key[0])
-        else:
-            # Per-sample keys [batch_size, 2] - vmap split over batch
-            encoder_rng, noise_rng = jax.vmap(jax.random.split)(key).swapaxes(0, 1)
+        encoder_rng, noise_rng = split_prng_key(key)
 
         if not deterministic and self.proprioception_noise_std > 0.0:
-            if noise_rng.ndim == 1:
-                noise = jax.random.normal(noise_rng, egocentric_obs.shape)
-            elif not obs_is_batched:
-                noise = jax.random.normal(noise_rng[0], egocentric_obs.shape)
-            else:
-                noise = jax.vmap(
-                    lambda rng_key, obs_i: jax.random.normal(rng_key, obs_i.shape)
-                )(noise_rng, egocentric_obs)
+            noise = sample_normal(noise_rng, egocentric_obs)
             egocentric_obs = egocentric_obs * (
                 1.0 + self.proprioception_noise_std * noise
             )
@@ -645,7 +628,7 @@ def make_recurrent_intention_ppo_networks(
             done_seq: Done flags with shape [T, B].
             key: Random key (used only if stored_keys is None).
             deterministic: If True, use latent mean instead of sampling.
-            stored_keys: Optional pre-stored RNG keys with shape [T, B, 2].
+            stored_keys: Optional pre-stored typed RNG keys with shape [T, B].
                 If provided, uses these for deterministic replay of stochastic
                 layers instead of generating fresh keys.
 
@@ -662,11 +645,12 @@ def make_recurrent_intention_ppo_networks(
         if stored_keys is not None:
             # Get expected shape from observations [T, B, ...]
             ref_obs = obs_seq_normalized["task_obs"]
-            expected_shape = (ref_obs.shape[0], ref_obs.shape[1], 2)
+            expected_shape = (ref_obs.shape[0], ref_obs.shape[1])
             if stored_keys.shape != expected_shape:
                 raise ValueError(
                     f"stored_keys has shape {stored_keys.shape}, expected {expected_shape}. "
-                    f"stored_keys must have shape [T, B, 2] matching the observation sequence."
+                    "stored_keys must have shape [T, B] matching the observation "
+                    "sequence."
                 )
 
         if stored_keys is not None:

--- a/track_mjx/agent/recurrent_ppo/networks.py
+++ b/track_mjx/agent/recurrent_ppo/networks.py
@@ -746,6 +746,7 @@ def make_recurrent_intention_ppo_networks(
         obs_sizes=obs_sizes,
         hidden_layer_sizes=value_hidden_layer_sizes,
         value_obs_key=value_obs_key,
+        activation=nn.silu,
     )
 
     return RecurrentPPONetworks(

--- a/track_mjx/agent/recurrent_ppo/networks.py
+++ b/track_mjx/agent/recurrent_ppo/networks.py
@@ -746,7 +746,6 @@ def make_recurrent_intention_ppo_networks(
         obs_sizes=obs_sizes,
         hidden_layer_sizes=value_hidden_layer_sizes,
         value_obs_key=value_obs_key,
-        activation=nn.silu,
     )
 
     return RecurrentPPONetworks(

--- a/track_mjx/agent/recurrent_ppo/ppo.py
+++ b/track_mjx/agent/recurrent_ppo/ppo.py
@@ -31,15 +31,13 @@ from brax.training.acme import running_statistics
 from brax.training.types import Params, PRNGKey
 from mujoco_playground import wrapper as mp_wrapper
 
+from track_mjx import training_wrappers
 from track_mjx.agent import checkpointing, gradients
 from track_mjx.agent.observation_utils import (
     get_obs_shape,
     get_obs_sizes,
 )
 from track_mjx.agent.recurrent_ppo import losses, networks
-from track_mjx.device_utils import patch_brax_pmap_compat, replicate_for_pmap
-
-patch_brax_pmap_compat()
 
 # Type aliases
 InferenceParams = tuple[running_statistics.RunningStatisticsState, Params]
@@ -47,7 +45,6 @@ Metrics = types.Metrics
 HiddenState = networks.HiddenState
 
 # Constants
-STEPS_IN_THOUSANDS = 1e3
 _PMAP_AXIS_NAME = "i"
 
 
@@ -60,18 +57,16 @@ class TrainingState:
         params: PPO network parameters (policy and value).
         normalizer_params: Running statistics for observation normalization.
             Has pytree structure matching observation dict.
-        env_steps: Total environment steps taken (in thousands).
     """
 
     optimizer_state: optax.OptState
     params: losses.RecurrentPPONetworkParams
     normalizer_params: running_statistics.RunningStatisticsState
-    env_steps: jnp.ndarray
 
 
 def _unpmap(v: Any) -> Any:
     """Extract first device's values from a pmap'd pytree."""
-    return jax.tree.map(lambda x: x[0], v)
+    return jax.tree.map(lambda x: x.addressable_shards[0].data.squeeze(0), v)
 
 
 def _strip_weak_type(tree: Any) -> Any:
@@ -79,6 +74,8 @@ def _strip_weak_type(tree: Any) -> Any:
 
     def f(leaf):
         leaf = jnp.asarray(leaf)
+        if jax.dtypes.issubdtype(leaf.dtype, jax.dtypes.prng_key):
+            return leaf
         return leaf.astype(leaf.dtype)
 
     return jax.tree.map(f, tree)
@@ -343,7 +340,7 @@ def train(
     checkpoint_callback: Callable[[int], None] | None = None,
     grad_clip_threshold: float = 20.0,
     wrap_for_training: Callable[..., mp_wrapper.Wrapper] = functools.partial(
-        mp_wrapper.wrap_for_brax_training, full_reset=False
+        training_wrappers.wrap_for_brax_training, full_reset=False
     ),
 ) -> tuple[Callable, InferenceParams, Metrics]:
     """Train a recurrent PPO agent on the given environment.
@@ -426,6 +423,9 @@ def train(
             * max(num_resets_per_eval, 1)
         )
     ).astype(int)
+    env_steps_per_training_epoch = int(
+        num_training_steps_per_epoch * env_step_per_training_step
+    )
 
     key = jax.random.key(seed)
     global_key, local_key = jax.random.split(key)
@@ -537,14 +537,15 @@ def train(
         optimizer_state=optimizer.init(init_params),
         params=init_params,
         normalizer_params=running_statistics.init_state(get_obs_shape(env_state.obs)),
-        env_steps=0,
     )
 
     # Load checkpoint if provided
+    current_step = 0
     if checkpoint_to_restore is not None:
         training_state = checkpointing.load_training_state(
             checkpoint_to_restore, training_state
         )
+        current_step = checkpointing.load_env_steps(checkpoint_to_restore)
         logging.info(f"Restored checkpoint from {checkpoint_to_restore}")
 
     gradient_update_fn = gradients.gradient_update_fn(
@@ -677,11 +678,6 @@ def train(
             optimizer_state=optimizer_state,
             params=params,
             normalizer_params=normalizer_params,
-            env_steps=jnp.asarray(
-                training_state.env_steps
-                + env_step_per_training_step / STEPS_IN_THOUSANDS,
-                dtype=jnp.int32,
-            ),
         )
         return (new_training_state, state, policy_hidden, new_key, it), metrics
 
@@ -721,7 +717,7 @@ def train(
         training_state, env_state, policy_hidden = _strip_weak_type(
             (training_state, env_state, policy_hidden)
         )
-        step = jnp.ones_like(training_state.env_steps) * it
+        step = jnp.full((local_devices_to_use,), it, dtype=jnp.int32)
         result = training_epoch(training_state, env_state, policy_hidden, key, step)
         training_state, env_state, policy_hidden, metrics = _strip_weak_type(result)
 
@@ -743,13 +739,12 @@ def train(
         return training_state, env_state, policy_hidden, metrics
 
     # Replicate training state across devices
-    devices = jax.local_devices()[:local_devices_to_use]
-    training_state = replicate_for_pmap(training_state, devices)
+    training_state = pmap.bcast_local_devices(training_state, local_devices_to_use)
 
     # Initialize policy hidden state for each device
     # Shape: [devices, envs_per_device, hidden_size]
     policy_hidden = recurrent_ppo_network.policy_network.init_hidden(envs_per_device)
-    policy_hidden = replicate_for_pmap(policy_hidden, devices)
+    policy_hidden = pmap.bcast_local_devices(policy_hidden, local_devices_to_use)
 
     # Setup evaluation
     if eval_env is None:
@@ -797,6 +792,7 @@ def train(
         if latest_step is not None:
             num_evals_after_init -= latest_step
             start_it = latest_step
+            current_step = checkpointing.restore_env_steps(ckpt_mgr, latest_step)
 
     logging.info(
         f"Starting at iteration: {start_it} with {num_evals_after_init} evals left"
@@ -819,26 +815,18 @@ def train(
 
         # Save initial checkpoint
         if ckpt_mgr is not None:
-            ckpt_mgr.save(
-                step=0,
-                args=ocp.args.Composite(
-                    policy=ocp.args.StandardSave(policy_param),
-                    train_state=ocp.args.StandardSave(_unpmap(training_state)),
-                    config=ocp.args.JsonSave(config_dict),
-                ),
+            checkpointing.save(
+                ckpt_mgr,
+                0,
+                policy_param,
+                _unpmap(training_state),
+                config_dict,
+                current_step,
+                checkpoint_callback,
             )
-            if checkpoint_callback is not None:
-                try:
-                    checkpoint_callback(0)
-                except OSError as e:
-                    logging.error(
-                        f"Initial checkpoint callback failed with I/O error: {e}. "
-                        "Training will continue but checkpoint state may be incomplete."
-                    )
 
     training_metrics = {}
     start_it += 1
-    current_step = 0
 
     for it in range(start_it, num_evals_after_init + start_it):
         logging.info("starting iteration %s %s", it, time.time() - xt)
@@ -854,7 +842,7 @@ def train(
             ) = training_epoch_with_timing(
                 training_state, env_state, policy_hidden, epoch_keys, it
             )
-            current_step = int(_unpmap(training_state.env_steps))
+            current_step += env_steps_per_training_epoch
 
             key_envs = jax.vmap(
                 lambda x, s: jax.random.split(x[0], s), in_axes=(0, None)
@@ -866,7 +854,9 @@ def train(
                 policy_hidden = recurrent_ppo_network.policy_network.init_hidden(
                     envs_per_device
                 )
-                policy_hidden = replicate_for_pmap(policy_hidden, devices)
+                policy_hidden = pmap.bcast_local_devices(
+                    policy_hidden, local_devices_to_use
+                )
 
         if process_id == 0:
             policy_param = _unpmap(
@@ -903,6 +893,7 @@ def train(
                     policy_param,
                     _unpmap(training_state),
                     config_dict,
+                    current_step,
                     checkpoint_callback,
                 )
 

--- a/track_mjx/agent/wandb_logging.py
+++ b/track_mjx/agent/wandb_logging.py
@@ -121,6 +121,10 @@ def rollout_logging_fn(
             commit=False,
         )
 
+    if cfg.logging_config.get("log_histograms", False):
+        log_histogram_to_wandb("eval/histograms/latent_means", means_mean.tolist())
+        log_histogram_to_wandb("eval/histograms/latent_stds", means_std.tolist())
+
     if render_video:
         _log_rollout_video(env, cfg, model_path, current_step, rollout)
 
@@ -149,16 +153,29 @@ def _log_rollout_video(
     metric_names = cfg.logging_config.get("rollout_metrics", reward_names)
     for metric in metric_names:
         if metric in rollout[0].metrics:
+            values = [s.metrics[metric] for s in rollout]
             log_lineplot_to_wandb(
                 name=f"eval/rollout_{metric}",
                 metric_name=metric,
-                data=list(enumerate([s.metrics[metric] for s in rollout])),
+                data=list(enumerate(values)),
                 title=f"{metric} per rollout frame",
             )
         else:
             logging.warning(
                 f"Rollout metric '{metric}' not found in environment metrics."
             )
+
+    # Log histograms of per-step reward distributions
+    if cfg.logging_config.get("log_histograms", False):
+        episode_rewards = [float(s.reward) for s in rollout]
+        log_histogram_to_wandb("eval/histograms/episode_reward", episode_rewards)
+        for metric in metric_names:
+            if metric in rollout[0].metrics:
+                values = [float(s.metrics[metric]) for s in rollout]
+                log_histogram_to_wandb(
+                    f"eval/histograms/{metric}",
+                    values,
+                )
 
     try:
         with imageio.get_writer(video_path, fps=render_fps) as writer:
@@ -216,27 +233,22 @@ def log_lineplot_to_wandb(
 
 
 def log_histogram_to_wandb(
-    name: str, metric_name: str, data: list[float], title: str
+    name: str,
+    data: list[float],
 ) -> None:
     """Log a histogram to Weights & Biases.
 
+    Uses ``wandb.Histogram`` for lightweight native histogram rendering
+    without creating intermediate tables.
+
     Args:
-        name: Wandb log key (e.g., "eval/latent_means_histogram").
-        metric_name: Name for the histogram metric.
-        data: List of values to include in the histogram.
-        title: Title displayed on the wandb plot.
+        name: Wandb log key (e.g., "eval/episode_reward_hist").
+        data: Values to include in the histogram.
 
     Note:
         Logged with commit=False; caller should batch with other logs.
     """
-    table = wandb.Table(
-        data=enumerate(data),
-        columns=["index", metric_name],
-    )
-    wandb.log(
-        {name: wandb.plot.histogram(table, value=metric_name, title=title)},  # type: ignore
-        commit=False,
-    )
+    wandb.log({name: wandb.Histogram(data)}, commit=False)
 
 
 def initialize_wandb_logging(

--- a/track_mjx/agent/wandb_logging.py
+++ b/track_mjx/agent/wandb_logging.py
@@ -311,8 +311,10 @@ def wandb_progress(num_steps: int, metrics: dict[str, Any]) -> None:
         module), so it should be called last in a logging batch.
     """
     metrics["num_steps_thousands"] = num_steps
+    summary_keys = set(wandb.run.summary.keys())
     for metric in metrics:
-        if metric not in wandb.run.summary:
+        if metric not in summary_keys:
             mode = "max" if "reward" in metric or "episode_length" in metric else "mean"
             wandb.run.define_metric(metric, summary=mode)
+            summary_keys.add(metric)
     wandb.log(metrics)

--- a/track_mjx/agent/wandb_logging.py
+++ b/track_mjx/agent/wandb_logging.py
@@ -12,9 +12,10 @@ from typing import Any
 import imageio
 import jax
 import mujoco
-import wandb
 from jax import numpy as jnp
 from omegaconf import DictConfig, OmegaConf
+
+import wandb
 
 
 def rollout_logging_fn(

--- a/track_mjx/agent/wandb_logging.py
+++ b/track_mjx/agent/wandb_logging.py
@@ -12,10 +12,9 @@ from typing import Any
 import imageio
 import jax
 import mujoco
+import wandb
 from jax import numpy as jnp
 from omegaconf import DictConfig, OmegaConf
-
-import wandb
 
 
 def rollout_logging_fn(

--- a/track_mjx/analysis/rollout.py
+++ b/track_mjx/analysis/rollout.py
@@ -7,7 +7,8 @@ Rollouts can be used for evaluation, visualization, or data collection.
 Supports both feedforward and recurrent policies.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from pathlib import Path
 from typing import Any
 
 import jax
@@ -19,7 +20,11 @@ from vnl_playground import registry
 from vnl_playground.tasks import wrappers as vnl_wrappers
 
 
-def create_environment(env_config: dict[str, Any] | DictConfig) -> mjx_env.MjxEnv:
+def create_environment(
+    env_config: dict[str, Any] | DictConfig,
+    reference_data_path: str | Path | None = None,
+    keep_clips_idx: Sequence[int] | None = None,
+) -> mjx_env.MjxEnv:
     """Create a VNL imitation learning environment from a configuration.
 
     Uses the vnl-playground registry to create the environment with reference
@@ -31,6 +36,10 @@ def create_environment(env_config: dict[str, Any] | DictConfig) -> mjx_env.MjxEn
         env_config: Environment configuration only (not the full training
             config). Must contain env_name, reference_data_path, clip_length,
             and optionally keep_clips_idx.
+        reference_data_path: Override for the reference clip H5 file path.
+            When provided, takes precedence over ``env_config.reference_data_path``.
+        keep_clips_idx: Override for the clip indices to keep.
+            When provided, takes precedence over ``env_config.keep_clips_idx``.
 
     Returns:
         A Brax-compatible environment with nested dictionary observations.
@@ -40,6 +49,10 @@ def create_environment(env_config: dict[str, Any] | DictConfig) -> mjx_env.MjxEn
         >>> env = create_environment(cfg.env_config)
         >>> state = env.reset(jax.random.key(0))
         >>> print(state.obs.keys())  # dict_keys(['state', 'privileged_state'])
+
+        >>> env = create_environment(
+        ...     cfg.env_config, reference_data_path="/data/my_clips.h5"
+        ... )
     """
     if isinstance(env_config, DictConfig):
         env_cfg_dict = OmegaConf.to_container(env_config, resolve=True)
@@ -48,12 +61,23 @@ def create_environment(env_config: dict[str, Any] | DictConfig) -> mjx_env.MjxEn
 
     env_cfg_ml = config_dict.ConfigDict(env_cfg_dict)
 
+    data_path = (
+        str(reference_data_path)
+        if reference_data_path is not None
+        else env_cfg_ml.reference_data_path
+    )
+    clips_idx = (
+        list(keep_clips_idx)
+        if keep_clips_idx is not None
+        else env_cfg_ml.get("keep_clips_idx", None)
+    )
+
     env_name = env_cfg_ml.env_name
     reference_clips = registry.load_reference_clips(
         env_name,
-        data_path=env_cfg_ml.reference_data_path,
+        data_path=data_path,
         n_frames_per_clip=env_cfg_ml.clip_length,
-        keep_clips_idx=env_cfg_ml.get("keep_clips_idx", None),
+        keep_clips_idx=clips_idx,
     )
     return vnl_wrappers.TrackMjxObsWrapper(
         registry.load(

--- a/track_mjx/device_utils.py
+++ b/track_mjx/device_utils.py
@@ -1,22 +1,9 @@
-"""JAX device placement and configuration utilities compatible with JAX 0.10.x.
-
-Provides:
-- Drop-in replacement for the removed jax.device_put_replicated using
-  NamedSharding (official migration guide: https://docs.jax.dev/en/latest/
-  migrate_pmap.html#drop-in-replacements)
-- Persistent JIT compilation caching for faster repeated experiments
-- Brax compatibility monkey-patches
-"""
+"""JAX runtime configuration utilities."""
 
 import os
-from collections.abc import Sequence
 from pathlib import Path
 
 import jax
-import jax.numpy as jnp
-import numpy as np
-from jax.sharding import Mesh, NamedSharding
-from jax.sharding import PartitionSpec as P
 
 _JIT_CACHE_CONFIGURED = False
 
@@ -46,46 +33,3 @@ def enable_jit_cache(cache_dir: str | None = None):
     jax.config.update("jax_compilation_cache_dir", cache_dir)
     jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
     jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
-
-
-def replicate_for_pmap(pytree, devices: Sequence[jax.Device]):
-    """Replicate a pytree across devices for use with jax.pmap.
-
-    Stacks each leaf along a new leading axis (one copy per device) and
-    shards that axis across the given devices via NamedSharding.
-    The resulting arrays have shape [len(devices), *original_shape],
-    which is the layout jax.pmap expects.
-
-    Args:
-        pytree: Arbitrary JAX pytree to replicate.
-        devices: Sequence of devices to distribute across.
-
-    Returns:
-        A pytree with the same structure, each leaf replicated and placed
-        on the target devices.
-    """
-    mesh = Mesh(np.array(devices), ("devices",))
-    sharding = NamedSharding(mesh, P("devices"))
-    return jax.tree.map(
-        lambda x: jax.device_put(jnp.stack([x] * len(devices)), sharding),
-        pytree,
-    )
-
-
-def patch_brax_pmap_compat():
-    """Monkey-patch brax.training.pmap.bcast_local_devices for JAX ≥0.10.
-
-    brax 0.14.x calls jax.device_put_replicated which was removed in
-    JAX 0.10.0. This patches the function to use the modern API.
-    Safe to call multiple times (idempotent).
-    """
-    try:
-        from brax.training import pmap as brax_pmap
-    except ImportError:
-        return
-
-    def _bcast_local_devices(value, local_devices_to_use=1):
-        devices = jax.local_devices()[:local_devices_to_use]
-        return replicate_for_pmap(value, devices)
-
-    brax_pmap.bcast_local_devices = _bcast_local_devices

--- a/track_mjx/random_utils.py
+++ b/track_mjx/random_utils.py
@@ -1,0 +1,34 @@
+"""Utilities for working with JAX typed PRNG keys."""
+
+import jax
+
+
+def is_batched_prng_key(key: jax.Array) -> bool:
+    """Return whether a typed PRNG key has a leading batch axis."""
+    return key.ndim > 0
+
+
+def split_prng_key(key: jax.Array, count: int = 2) -> tuple[jax.Array, ...]:
+    """Split one key or each key in a one-dimensional key batch."""
+    if not is_batched_prng_key(key):
+        return tuple(jax.random.split(key, count))
+    if key.ndim != 1:
+        raise ValueError(f"Expected a scalar or 1D PRNG key batch, got {key.shape}")
+    split_keys = jax.vmap(lambda item: jax.random.split(item, count))(key)
+    return tuple(split_keys[:, index] for index in range(count))
+
+
+def sample_normal(key: jax.Array, reference: jax.Array) -> jax.Array:
+    """Sample normal noise matching a tensor and its optional key batch."""
+    if not is_batched_prng_key(key):
+        return jax.random.normal(key, reference.shape, dtype=reference.dtype)
+    if key.ndim != 1:
+        raise ValueError(f"Expected a scalar or 1D PRNG key batch, got {key.shape}")
+    if reference.ndim == 0 or key.shape[0] != reference.shape[0]:
+        raise ValueError(
+            "A batched PRNG key must match the tensor's leading dimension: "
+            f"key={key.shape}, tensor={reference.shape}"
+        )
+    return jax.vmap(
+        lambda item_key, item: jax.random.normal(item_key, item.shape, dtype=item.dtype)
+    )(key, reference)

--- a/track_mjx/training_wrappers.py
+++ b/track_mjx/training_wrappers.py
@@ -1,0 +1,65 @@
+"""Training wrappers whose bookkeeping is independent of PRNG representation."""
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from brax.envs.wrappers import training as brax_training
+from mujoco_playground import wrapper as playground_wrapper
+
+
+class EpisodeWrapper(brax_training.EpisodeWrapper):
+    """Tracks episode metrics using the environment state's batch shape."""
+
+    def reset(self, rng: jax.Array):
+        state = self.env.reset(rng)
+        state.info["steps"] = jnp.zeros_like(state.done)
+        state.info["truncation"] = jnp.zeros_like(state.done)
+        state.info["episode_done"] = jnp.zeros_like(state.done)
+        episode_metrics = {
+            "sum_reward": jnp.zeros_like(state.reward),
+            "length": jnp.zeros_like(state.done),
+        }
+        episode_metrics.update(
+            {name: jnp.zeros_like(value) for name, value in state.metrics.items()}
+        )
+        state.info["episode_metrics"] = episode_metrics
+        return state
+
+
+class AutoResetWrapper(playground_wrapper.BraxAutoResetWrapper):
+    """Auto-reset wrapper with per-environment typed-key bookkeeping."""
+
+    def reset(self, rng: jax.Array):
+        rng_key = jax.vmap(jax.random.split)(rng)
+        next_rng, reset_key = rng_key[..., 0], rng_key[..., 1]
+        state = self.env.reset(reset_key)
+        state.info[f"{self._info_key}_first_data"] = state.data
+        state.info[f"{self._info_key}_first_obs"] = state.obs
+        state.info[f"{self._info_key}_rng"] = next_rng
+        state.info[f"{self._info_key}_done_count"] = jnp.zeros_like(
+            state.done, dtype=int
+        )
+        return state
+
+
+def wrap_for_brax_training(
+    env: Any,
+    vision: bool = False,
+    num_vision_envs: int = 1,
+    episode_length: int = 1000,
+    action_repeat: int = 1,
+    randomization_fn=None,
+    full_reset: bool = False,
+):
+    """Wrap an environment for Brax training using typed JAX keys."""
+    if vision:
+        env = playground_wrapper.MadronaWrapper(env, num_vision_envs, randomization_fn)
+    elif randomization_fn is None:
+        env = brax_training.VmapWrapper(env)
+    else:
+        env = playground_wrapper.BraxDomainRandomizationVmapWrapper(
+            env, randomization_fn
+        )
+    env = EpisodeWrapper(env, episode_length, action_repeat)
+    return AutoResetWrapper(env, full_reset=full_reset)


### PR DESCRIPTION
## Summary

Batch of quality-of-life improvements and bug fixes across training, logging,
analysis utilities, and the JAX/Brax training stack.

- **Migrate the training stack to JAX 0.10**: Upgrade to JAX/JAXlib 0.10.2,
  Flax 0.12.7, wandb 0.28.0, and Brax 0.14.2 resolved from an exact upstream
  revision containing the required JAX 0.10 device-placement support. This
  removes the local Brax `pmap` compatibility monkeypatch.
- **Support typed PRNG keys end to end**: Add shared utilities for splitting
  scalar or batched typed keys and sampling matching noise. Update both FF and
  recurrent PPO paths to avoid assumptions about legacy key storage layouts.
- **Add typed-key-compatible training wrappers**: Derive episode bookkeeping
  shapes from environment state instead of the PRNG key representation. This
  fixes Brax and MuJoCo Playground wrappers that assumed legacy keys ended in
  a size-2 axis.
- **Preserve exact training progress**: Track environment steps as an unbounded
  host-side Python integer and store the exact value in checkpoint metadata.
  This removes lossy rounding to thousands and avoids the previous JAX int32
  limit for long training runs.
- **Modernize replicated-state extraction**: Extract local values from
  `pmap` results through JAX addressable shards instead of relying on deprecated
  array behavior.
- **Pass SiLU activation to value network**: The value network was silently
  using Brax's default activation instead of SiLU, creating a mismatch with the
  policy network. Now explicitly passes `activation=nn.silu` through both FF and
  recurrent PPO paths.
- **Wire histogram logging**: The existing `log_histogram_to_wandb` helper was
  never called. Now logs per-step reward distributions and latent statistics as
  `wandb.Histogram` when `logging_config.log_histograms: true` is set.
- **Move wandb init earlier**: wandb now initializes right after config prep
  and run-state discovery, before clip loading and environment creation, giving
  visibility into the long startup phase.
- **Add rollout API overrides**: `rollout.create_environment` now accepts
  optional `reference_data_path` and `keep_clips_idx` parameters, eliminating
  the need for callers to mutate config dictionaries.
- **Guard against zero clips**: Training now raises a clear error when
  `train_subset_ratio` yields zero training clips and gracefully skips test-set
  evaluation when there are zero test clips.
- **Style compliance**: Fix the domain randomization module docstring, add
  Google-style docstrings, replace magic numbers with named constants, and
  replace remaining `os.path` calls with `pathlib`.

## Closes

- Closes #142
- Closes #217
- Closes #34
- Closes #229
- Closes #137
- Closes #136