### PR TITLE
Update VNL and MJX compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ Expected output:
     conda activate track-mjx
     ```
 4. Install the package with desired CUDA version:
-    If your machine supports up to CUDA 13:
+    If your machine supports CUDA 12:
     ```bash
     pip install -e ".[cuda12]"
     ```
-    If your machine supports up to CUDA 12:
+    If your machine supports CUDA 13:
     ```bash
     pip install -e ".[cuda13]"
     ```
@@ -143,11 +143,17 @@ The main training entrypoint is defined in [`scripts/train.py`](scripts/train.py
 
 #### Download the data
 
-To download data, run `notebooks/rodent_demo.ipynb`
+The complete dataset is about 101 GB and contains reference motion for rodent,
+fruit fly, mouse arm, stick, and worm tasks. Download it into the repository's
+`data/` directory so the bundled task configs resolve it automatically:
 
-##### OR
+```bash
+uv run hf download talmolab/MIMIC-MJX --repo-type dataset --include 'data/**' --local-dir .
+```
 
-Execute the following command in terminal
+To download only the rodent reference clips, run
+`notebooks/rodent_demo.ipynb` or execute:
+
 ```bash
 python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id='talmolab/MIMIC-MJX', repo_type='dataset', filename='data/rodent/rodent_reference_clips.h5', local_dir='.')"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,18 @@ authors = [
 description=  "Track-MJX: A Python package for fast reinforcement learning-based imitation learning tracking for agents"
 requires-python = ">=3.12,<3.13"
 keywords = ["tracking", "imitation learning", "deep learning"]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
 classifiers = [
     "Programming Language :: Python :: 3.12"]
 dependencies = [
     "jax==0.10.2",
     "jaxlib==0.10.2",
-    "brax==0.14.2",
+    "brax @ git+https://github.com/google/brax.git@303d89dfac42919e5fde7c91f24c28a505373b24",
     "flax==0.12.7",
     "optax==0.2.8",
     "orbax-checkpoint==0.12.0",
-    "mujoco==3.8.1",
-    "mujoco-mjx[warp]==3.8.1",
+    "mujoco==3.11.0",
+    "mujoco-mjx[warp]==3.11.0",
     "PyOpenGL==3.1.9",
     "numpy==2.1.3",
     "h5py==3.12.1",
@@ -38,9 +38,9 @@ dependencies = [
     "wandb==0.28.0",
     "huggingface-hub==1.20.1",
     "jaxtyping>=0.2.34",
-    "playground",
+    "playground @ git+https://github.com/google-deepmind/mujoco_playground.git@b63fcb5db02a0f27aaf2b29ce6fc14c75489fa16",
     "ipykernel",
-    "vnl-playground",
+    "vnl-playground @ git+https://github.com/talmolab/vnl-playground.git@860cdfbefc1fdd00ca290e697c12178dd6e4e48d",
 ]
 
 dynamic = ["version", "readme"]
@@ -75,7 +75,10 @@ dev = [
 Repository = "https://github.com/talmolab/track-mjx"
 
 [tool.setuptools.packages.find]
-exclude = ["site", "model_checkpoints*", "wandb", "outputs"]
+include = ["track_mjx*"]
+
+[tool.setuptools.package-data]
+track_mjx = ["py.typed", "config/*.yaml"]
 
 [tool.ruff]
 line-length = 88
@@ -109,13 +112,7 @@ ignore = [
 [tool.ruff.lint.isort]
 known-first-party = ["track_mjx"]
 
-[tool.uv.sources]
-brax = { git = "https://github.com/google/brax", rev = "1aa46f127bc4208d0c6de350a58ef00c8f01b0d9" }
-vnl-playground = { git = "https://github.com/talmolab/vnl-playground", rev = "1529ac42d952c41b9408f8bebbb25602f3881ad3" }
-playground = { git = "https://github.com/google-deepmind/mujoco_playground", rev = "b63fcb5db02a0f27aaf2b29ce6fc14c75489fa16" }
-
 [tool.uv]
-override-dependencies = ["brax==0.14.2"]
 no-sources-package = ["mujoco", "mujoco-mjx"]
 
 [dependency-groups]

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -99,15 +99,13 @@ def main(cfg: DictConfig) -> None:
     env_name = cfg.env_config.env_name
     default_config = registry.get_default_config(env_name)
 
+    clip_indices = cfg.env_config.get("clip_indices", None)
+
     reference_clips = registry.load_reference_clips(
         env_name,
         data_path=cfg.env_config.reference_data_path,
         n_frames_per_clip=cfg.env_config.clip_length,
-        keep_clips_idx=(
-            np.asarray(cfg.env_config.keep_clips_idx)
-            if cfg.env_config.keep_clips_idx is not None
-            else None
-        ),
+        clip_indices=np.asarray(clip_indices) if clip_indices is not None else None,
         joint_names=cfg.env_config.get("joints", default_config.get("joints", None)),
         body_names=cfg.env_config.get("bodies", default_config.get("bodies", None)),
     )
@@ -126,8 +124,19 @@ def main(cfg: DictConfig) -> None:
             f"training clips. Increase the ratio or add more clips."
         )
 
+    training_worlds_per_device = (
+        int(cfg.train_setup.train_config.num_envs) // n_devices
+    )
+    num_eval_envs = int(cfg.train_setup.train_config.get("num_eval_envs", 128))
+
     env = rodent_wrappers.TrackMjxObsWrapper(
-        registry.load(env_name, config=env_cfg_ml, clips=train_clips, flatten_obs=False)
+        registry.load(
+            env_name,
+            config=env_cfg_ml,
+            clips=train_clips,
+            flatten_obs=False,
+            num_worlds=training_worlds_per_device,
+        )
     )
     try:
         xml = env.save_spec("./env_spec.xml", return_str=True)
@@ -143,7 +152,11 @@ def main(cfg: DictConfig) -> None:
     else:
         test_env = rodent_wrappers.TrackMjxObsWrapper(
             registry.load(
-                env_name, config=env_cfg_ml, clips=test_clips, flatten_obs=False
+                env_name,
+                config=env_cfg_ml,
+                clips=test_clips,
+                flatten_obs=False,
+                num_worlds=num_eval_envs,
             )
         )
 
@@ -277,6 +290,7 @@ def main(cfg: DictConfig) -> None:
             config=rollout_cfg,
             clips=reference_clips,
             flatten_obs=False,
+            num_worlds=1,
         )
     )
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -124,9 +124,7 @@ def main(cfg: DictConfig) -> None:
             f"training clips. Increase the ratio or add more clips."
         )
 
-    training_worlds_per_device = (
-        int(cfg.train_setup.train_config.num_envs) // n_devices
-    )
+    training_worlds_per_device = int(cfg.train_setup.train_config.num_envs) // n_devices
     num_eval_envs = int(cfg.train_setup.train_config.get("num_eval_envs", 128))
 
     env = rodent_wrappers.TrackMjxObsWrapper(

--- a/scripts/train_highlvl.py
+++ b/scripts/train_highlvl.py
@@ -104,8 +104,11 @@ def create_environments(
     highlvl_obs_key: str,
     policy_obs_key: str = "state",
     value_obs_key: str = "state",
+    num_envs: int = 4096,
+    num_eval_envs: int = 128,
 ):
     """Create training and eval environments with HighLevelWrapper."""
+    training_worlds_per_device = num_envs // jax.device_count()
     wrapper_kwargs = dict(
         decoder_inference_fn=decoder_policy_fn,
         latent_size=intention_size,
@@ -115,11 +118,23 @@ def create_environments(
         lowlvl_obs_key="proprioception",
     )
     env = rodent_wrappers.HighLevelWrapper(
-        registry.load(task_name, config=env_cfg, clips=None, flatten_obs=False),
+        registry.load(
+            task_name,
+            config=env_cfg,
+            clips=None,
+            flatten_obs=False,
+            num_worlds=training_worlds_per_device,
+        ),
         **wrapper_kwargs,
     )
     eval_env = rodent_wrappers.HighLevelWrapper(
-        registry.load(task_name, config=env_cfg, clips=None, flatten_obs=False),
+        registry.load(
+            task_name,
+            config=env_cfg,
+            clips=None,
+            flatten_obs=False,
+            num_worlds=num_eval_envs,
+        ),
         **wrapper_kwargs,
     )
     return env, eval_env
@@ -179,7 +194,7 @@ def main():
     default_num_envs = 1024 if is_warp else 4096
     ppo_params = create_ppo_params(args, default_num_envs=default_num_envs)
 
-    # Set Warp defaults first, then apply all user overrides (can override naconmax, njmax)
+    # Set Warp defaults first, then apply all user overrides (including capacities).
     if is_warp:
         env_cfg.mujoco_impl = "warp"
         configure_warp_backend(env_cfg, ppo_params.num_envs, task_name=args.task)
@@ -232,6 +247,8 @@ def main():
         args.highlvl_obs_key,
         policy_obs_key=args.policy_obs_key,
         value_obs_key=args.value_obs_key,
+        num_envs=ppo_params.num_envs,
+        num_eval_envs=ppo_params.num_eval_envs,
     )
 
     # Setup training

--- a/scripts/train_task.py
+++ b/scripts/train_task.py
@@ -11,6 +11,11 @@ Usage:
     # Basic usage (any registered task)
     python train_task.py --task RodentBowlEscape
     python train_task.py --task RodentRearing
+    python train_task.py --task RodentImitation
+
+    # Override the bundled MIMIC-MJX path when using custom reference data
+    python train_task.py --task RodentImitation \
+        --env "reference_data_path=/path/to/reference_clips.h5"
 
     # With PPO overrides
     python train_task.py --task RodentRearing --num_timesteps 1e8 --entropy_cost 0.1
@@ -24,7 +29,7 @@ Usage:
 
     # Warp backend (full-collision rodent model)
     python train_task.py --task RodentBowlEscape --env "mujoco_impl=warp"
-    python train_task.py --task RodentBowlEscape --env "mujoco_impl=warp naconmax=92160 njmax=1200"
+    python train_task.py --task RodentBowlEscape --env "mujoco_impl=warp contacts_per_world=20 constraints_per_world=600"
 """
 
 import os
@@ -64,15 +69,29 @@ from vnl_playground import registry
 from vnl_playground.tasks import wrappers as rodent_wrappers
 
 from track_mjx import training_wrappers
+from track_mjx.config.utils import get_track_env_overrides
 
 
-def create_environments(task_name, env_cfg):
+def create_environments(task_name, env_cfg, num_envs, num_eval_envs):
     """Create training and eval environments."""
+    training_worlds_per_device = num_envs // jax.device_count()
     env = rodent_wrappers.BraxObsWrapper(
-        registry.load(task_name, config=env_cfg, clips=None, flatten_obs=False)
+        registry.load(
+            task_name,
+            config=env_cfg,
+            clips=None,
+            flatten_obs=False,
+            num_worlds=training_worlds_per_device,
+        )
     )
     eval_env = rodent_wrappers.BraxObsWrapper(
-        registry.load(task_name, config=env_cfg, clips=None, flatten_obs=False)
+        registry.load(
+            task_name,
+            config=env_cfg,
+            clips=None,
+            flatten_obs=False,
+            num_worlds=num_eval_envs,
+        )
     )
     return env, eval_env
 
@@ -109,13 +128,19 @@ def main():
     # Create configs
     cli_env_overrides = parse_env_overrides_str(args.env)
     env_cfg = registry.get_default_config(args.task)
+    track_defaults = get_track_env_overrides(args.task)
+    if "reference_data_path" in track_defaults:
+        apply_env_overrides(
+            env_cfg,
+            {"reference_data_path": track_defaults["reference_data_path"]},
+        )
 
     # Detect Warp from parsed overrides (before applying to env_cfg)
     is_warp = cli_env_overrides.get("mujoco_impl") == "warp"
     default_num_envs = 1024 if is_warp else 4096
     ppo_params = create_ppo_params(args, default_num_envs=default_num_envs)
 
-    # Set Warp defaults first, then apply all user overrides (can override naconmax, njmax)
+    # Set Warp defaults first, then apply all user overrides (including capacities).
     if is_warp:
         env_cfg.mujoco_impl = "warp"
         configure_warp_backend(env_cfg, ppo_params.num_envs, task_name=args.task)
@@ -164,7 +189,9 @@ def main():
         wandb.log(metrics)
 
     # Create environments
-    env, eval_env = create_environments(args.task, env_cfg)
+    env, eval_env = create_environments(
+        args.task, env_cfg, ppo_params.num_envs, ppo_params.num_eval_envs
+    )
 
     # Setup training
     training_params = get_training_params(ppo_params)

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -42,7 +42,11 @@ def apply_env_overrides(env_cfg: Any, overrides: dict) -> None:
         try:
             for part in parts[:-1]:
                 obj = getattr(obj, part)
-            setattr(obj, parts[-1], value)
+            field = parts[-1]
+            current_value = getattr(obj, field)
+            if isinstance(current_value, epath.Path) and isinstance(value, str):
+                value = epath.Path(value)
+            setattr(obj, field, value)
         except AttributeError as e:
             raise ValueError(
                 f"Invalid env config override '{key}={value}': {e}. "
@@ -79,6 +83,7 @@ DEFAULT_PPO_PARAMS = {
     "learning_rate": 1e-4,
     "entropy_cost": 0.01,
     "num_envs": 4096,
+    "num_eval_envs": 128,
     "batch_size": 1024,
     "max_grad_norm": 1.0,
     "eval_every": 5_000_000,

--- a/track_mjx/analysis/rollout.py
+++ b/track_mjx/analysis/rollout.py
@@ -23,7 +23,8 @@ from vnl_playground.tasks import wrappers as vnl_wrappers
 def create_environment(
     env_config: dict[str, Any] | DictConfig,
     reference_data_path: str | Path | None = None,
-    keep_clips_idx: Sequence[int] | None = None,
+    clip_indices: Sequence[int] | None = None,
+    num_worlds: int = 1,
 ) -> mjx_env.MjxEnv:
     """Create a VNL imitation learning environment from a configuration.
 
@@ -35,11 +36,14 @@ def create_environment(
     Args:
         env_config: Environment configuration only (not the full training
             config). Must contain env_name, reference_data_path, clip_length,
-            and optionally keep_clips_idx.
+            and optionally clip_indices.
         reference_data_path: Override for the reference clip H5 file path.
             When provided, takes precedence over ``env_config.reference_data_path``.
-        keep_clips_idx: Override for the clip indices to keep.
-            When provided, takes precedence over ``env_config.keep_clips_idx``.
+        clip_indices: Override for the clip indices to keep.
+            When provided, takes precedence over ``env_config.clip_indices``.
+        num_worlds: Number of environments sharing the MJX-Warp model. This
+            controls allocation of per-world contact capacity for batched Warp
+            rollouts and defaults to 1 for a single rollout.
 
     Returns:
         A Brax-compatible environment with nested dictionary observations.
@@ -66,10 +70,10 @@ def create_environment(
         if reference_data_path is not None
         else env_cfg_ml.reference_data_path
     )
-    clips_idx = (
-        list(keep_clips_idx)
-        if keep_clips_idx is not None
-        else env_cfg_ml.get("keep_clips_idx", None)
+    selected_clip_indices = (
+        list(clip_indices)
+        if clip_indices is not None
+        else env_cfg_ml.get("clip_indices", None)
     )
 
     env_name = env_cfg_ml.env_name
@@ -77,11 +81,15 @@ def create_environment(
         env_name,
         data_path=data_path,
         n_frames_per_clip=env_cfg_ml.clip_length,
-        keep_clips_idx=clips_idx,
+        clip_indices=selected_clip_indices,
     )
     return vnl_wrappers.TrackMjxObsWrapper(
         registry.load(
-            env_name, config=env_cfg_ml, clips=reference_clips, flatten_obs=False
+            env_name,
+            config=env_cfg_ml,
+            clips=reference_clips,
+            flatten_obs=False,
+            num_worlds=num_worlds,
         )
     )
 

--- a/track_mjx/config/celegans.yaml
+++ b/track_mjx/config/celegans.yaml
@@ -95,6 +95,7 @@ env_config:
   # ---------------------------------------------------------------------------
   reference_length: 5                 # Future reference frames provided to policy
   start_frame_range: [0, 50]          # Random episode start within [min, max] frames
+  clip_indices: null                  # Specific clip indices to use (null = all)
   mujoco_impl: jax                    # MuJoCo backend: "jax" for GPU via MJX
 
   # ---------------------------------------------------------------------------

--- a/track_mjx/config/fly.yaml
+++ b/track_mjx/config/fly.yaml
@@ -25,8 +25,8 @@ env_config:
   solver: "cg"
   iterations: 5
   ls_iterations: 5
-  naconmax: 10240
-  njmax: 20
+  contacts_per_world: 5
+  constraints_per_world: 20
   noslip_iterations: 0
 
   # ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ env_config:
   reference_length: 5
   start_frame_range: [0, 50]
   qvel_init: "zeros"
-  keep_clips_idx: null
+  clip_indices: null
 
   # ---------------------------------------------------------------------------
   # Domain Randomization Settings

--- a/track_mjx/config/rodent-full-clips.yaml
+++ b/track_mjx/config/rodent-full-clips.yaml
@@ -26,9 +26,8 @@ env_config:
   solver: "newton"
   iterations: 5           # Max solver iterations per step
   ls_iterations: 5        # Line search iterations for Newton solver
-  nconmax: 32             # Max contacts (increase if contact clipping occurs)
-  naconmax: 131072        # Max arena contacts
-  njmax: 128              # Max constraint rows
+  contacts_per_world: 32      # Contact capacity allocated per environment
+  constraints_per_world: 128  # Constraint capacity allocated per environment
   noslip_iterations: 0    # No-slip solver iterations (0 = disabled)
 
   # -----------------------------------------------------------------------------
@@ -47,7 +46,7 @@ env_config:
   reference_length: 5             # Future reference frames provided to policy
   start_frame_range: [0, 50]      # Random episode start within [min, max] frames
   qvel_init: "zeros"              # Initial velocity: "zeros" or "reference"
-  keep_clips_idx: null            # Specific clip indices to use (null = all)
+  clip_indices: null              # Specific clip indices to use (null = all)
 
   # -----------------------------------------------------------------------------
   # Domain Randomization Settings

--- a/track_mjx/config/rodent-recurrent.yaml
+++ b/track_mjx/config/rodent-recurrent.yaml
@@ -19,9 +19,8 @@ env_config:
   solver: "newton"
   iterations: 5
   ls_iterations: 5
-  nconmax: 256
-  naconmax: 131072
-  njmax: 128
+  contacts_per_world: 32
+  constraints_per_world: 128
   noslip_iterations: 0
 
   # Timing Configuration
@@ -35,7 +34,7 @@ env_config:
   reference_length: 5
   start_frame_range: [0, 50]
   qvel_init: "zeros"
-  keep_clips_idx: null
+  clip_indices: null
 
   # Domain Randomization Settings
   domain_randomization:

--- a/track_mjx/config/utils.py
+++ b/track_mjx/config/utils.py
@@ -79,12 +79,37 @@ _TRACK_ENV_OVERRIDES_BY_ENV_NAME: dict[str, dict[str, Any]] = {
             "data/rodent/rodent_reference_clips.h5"
         ),
     },
+    "RodentSparseImitation": {
+        "walker_name": "rodent",
+        "walker_xml_path": str(rodent_consts.RODENT_XML_PATH),
+        "arena_xml_path": str(rodent_consts.ARENA_XML_PATH),
+        "reference_data_path": _resolve_data_path(
+            "data/rodent/rodent_reference_clips.h5"
+        ),
+    },
     "FruitflyImitation": {
         "walker_name": "fruitfly",
         "walker_xml_path": str(fruitfly_consts.FRUITFLY_XML_PATH),
         "arena_xml_path": str(fruitfly_consts.ARENA_XML_PATH),
+        "reference_data_path": _resolve_data_path("data/fly/fly_reference_clip.h5"),
+    },
+    "MouseImitation": {
+        "reference_data_path": _resolve_data_path("data/mouse_arm"),
+    },
+    "StickImitation": {
         "reference_data_path": _resolve_data_path(
-            "data/fruitfly/fly_reference_clip.h5"
+            "data/stick/stick_box_model_reference.h5"
+        ),
+    },
+    "WormImitation": {
+        "reference_data_path": _resolve_data_path(
+            "data/worm/celegans_ik_only_04182019am_centerline_locomotion_2d.h5"
+        ),
+    },
+    # CelegansImitation is a backwards-compatible registry alias for WormImitation.
+    "CelegansImitation": {
+        "reference_data_path": _resolve_data_path(
+            "data/worm/celegans_ik_only_04182019am_centerline_locomotion_2d.h5"
         ),
     },
 }
@@ -106,20 +131,11 @@ def _to_omegaconf_compatible(value: Any) -> Any:
     return value
 
 
-def _get_track_env_overrides(env_name: str) -> dict[str, Any]:
+def get_track_env_overrides(env_name: str) -> dict[str, Any]:
     """Return track-mjx-specific env overrides for a given env_name."""
     overrides = _TRACK_ENV_OVERRIDES_BY_ENV_NAME.get(env_name)
-    if overrides is not None:
-        # Return a copy so callers cannot mutate module-level defaults.
-        return dict(overrides)
-
-    if env_name:
-        logging.warning(
-            "No track-mjx-specific env overrides found for env_name='%s'. "
-            "Using vnl-playground defaults and user env_config only.",
-            env_name,
-        )
-    return {}
+    # Return a copy so callers cannot mutate module-level defaults.
+    return dict(overrides) if overrides is not None else {}
 
 
 def _merge_env_config_with_defaults(cfg: DictConfig) -> DictConfig:
@@ -149,7 +165,13 @@ def _merge_env_config_with_defaults(cfg: DictConfig) -> DictConfig:
             "Expected a registered vnl_playground task name."
         ) from exc
 
-    track_overrides = _get_track_env_overrides(env_name)
+    track_overrides = get_track_env_overrides(env_name)
+    if not track_overrides:
+        logging.warning(
+            "No track-mjx-specific env overrides found for env_name='%s'. "
+            "Using vnl-playground defaults and user env_config only.",
+            env_name,
+        )
 
     merged_env_cfg = OmegaConf.merge(
         OmegaConf.create(_to_omegaconf_compatible(default_env_cfg.to_dict())),

--- a/track_mjx/config/v1_rodent_imitation_warp.yaml
+++ b/track_mjx/config/v1_rodent_imitation_warp.yaml
@@ -26,8 +26,8 @@ env_config:
   solver: "newton"
   iterations: 5           # Max solver iterations per step
   ls_iterations: 5        # Line search iterations for Newton solver
-  nconmax: 20            # Max contacts (increase if contact clipping occurs)
-  njmax: 600              # Max constraint rows
+  contacts_per_world: 20      # Contact capacity allocated per environment
+  constraints_per_world: 600  # Constraint capacity allocated per environment
   noslip_iterations: 0    # No-slip solver iterations (0 = disabled)
 
   # -----------------------------------------------------------------------------
@@ -46,7 +46,7 @@ env_config:
   reference_length: 5             # Future reference frames provided to policy
   start_frame_range: [0, 50]      # Random episode start within [min, max] frames
   qvel_init: "zeros"              # Initial velocity: "zeros" or "reference"
-  keep_clips_idx: null            # Specific clip indices to use (null = all)
+  clip_indices: null              # Specific clip indices to use (null = all)
 
   # -----------------------------------------------------------------------------
   # Domain Randomization Settings


### PR DESCRIPTION
Updates Track-MJX for the latest VNL Playground and MJX/Warp APIs. Pins compatible dependencies for both pip and uv, migrates clip and per-world capacity configuration, fixes batched environment sizing, and adds automatic MIMIC-MJX dataset paths for tutorial training tasks.